### PR TITLE
fix(voices): remove fabricated URLs + add HEAD-check defense

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,22 @@ npx prettier --write src/
 - 自动管线已强制：`scripts/lib/auto-discovered-emit.ts` 和各 `emit.ts` 在 emit 后跑 `findUnpairedFields` baseline-vs-after diff，新引入 unpaired 自动 rollback；不会"偷偷"放出单语种数据。
 - 未来扩展到 ja / ko 等语言时，本规则升级为"有几个语言就更新几个，所有目标语种同 commit 同步"。当前 (2026-05) 范围是 zh + en。
 
+### 6. sourceUrl 真实性约定（关键 — 最高优先级）
+
+> **🔴 顶层硬规则：任何写入 `src/data/*.ts` 的 `sourceUrl` / `url` 字段必须 HTTP 可达（2xx/3xx，或 401/403/429 这类反爬但页面真实存在）。404/410/5xx/DNS 失败一律禁止入库。**
+>
+> 触发场景：所有"靠 LLM 补脑"的内容流程——voices prospect、人工编辑、粘贴翻译、agent 批量回填等。和 hansard / videos 这类先有 API ground-truth 再 emit 的管线不同，这类流程对 URL 幻觉零防御。
+>
+> - ❌ 禁止凭训练记忆/格式推断构造 URL。LLM 会在 URL 模式正确（如 `fintechfestival.sg/speakers/spkr<NUMBER>-<slug>`）时填一个看似合理但**从未存在**的 ID。这种幻觉肉眼几乎无法识别，必须靠 HTTP 校验兜底。
+> - ✅ 加 / 改 sourceUrl：必须先 `curl -I` 或 fetch 验证 200/3xx，再写入。
+> - ✅ 不确定？用 [scripts/lib/gov-fetch.ts](scripts/lib/gov-fetch.ts) 的 fetch helper 真去抓一遍。
+> - ✅ schema 允许 sourceUrl 可选时（如 `SignatureWork` / `SpeakingEntry` / `ExternalRole`），找不到可信源就**留空**比写假的好；`NotableQuote.sourceUrl` 是 required，找不到就整条删。
+> - ✅ 真的"页面被反爬挡了但内容确实存在"：在 prospect JSON 的 `notes` 字段写明白验证依据（如"archive.org 快照确认"），并通过 `--skip-url-check` 显式豁免。
+>
+> 强制点：`scripts/voices/prospect-stubs.mjs apply` 在 print TS 片段前会 HEAD-check 所有 sourceUrl，4xx/5xx（除 401/403/429）blocks apply 退码 2。新加的"靠 LLM 补脑"型管线**必须**复用同样的 `validateUrls()` 检查。
+
+历史踩点：[c574e54](https://github.com/meltflake/sgai/commit/c574e54)（2026-05-03 voices backfill）写入 2 条编造 URL（`spkr4563-prof-mohan-kankanhalli`、`asianaviation.com/astar-sia-siaec-...`），加 2 条 weforum 反爬伪 404。当时无 URL 校验，靠用户事后报错才发现。本规则即此次事故的事后加固。
+
 ## 项目结构
 
 ```

--- a/scripts/lib/url-check.ts
+++ b/scripts/lib/url-check.ts
@@ -1,0 +1,117 @@
+// URL reachability validator for "LLM-supplemented" data pipelines.
+//
+// Front-line defense against fabricated URLs whose format looks right
+// but the page never existed (e.g. `fintechfestival.sg/speakers/spkr<NUMBER>-<slug>`
+// where the slug is real but the spkr ID was hallucinated).
+//
+// Per CLAUDE.md rule #6 (sourceUrl 真实性约定): every "LLM 补脑" pipeline
+// — voices prospect, manual edits, agent batch backfill, etc. — must run
+// every sourceUrl through this check before writing to src/data/*.ts.
+//
+// Pipelines that already have ground-truth APIs (hansard SPRS, YouTube)
+// don't need this — the URL is asserted by the upstream API, not invented.
+
+export type UrlCheckEntry = {
+  url: string;
+  /** Where in the prospect record the url lives, e.g. 'signatureWork[2].sourceUrl'. Used for error reports only. */
+  context?: string;
+};
+
+export type UrlCheckResult = {
+  url: string;
+  context?: string;
+  /** HTTP status number, or `'ERR:<name>'` for fetch failures. */
+  status: number | string;
+};
+
+export type ValidateOptions = {
+  /** Max parallel fetches. Default 6. */
+  concurrency?: number;
+  /** Per-request timeout. Default 10 s. */
+  timeoutMs?: number;
+};
+
+/**
+ * Treat as "reachable enough":
+ * - 2xx, 3xx — page exists.
+ * - 401 / 403 / 429 — bot wall, paywall, or rate limit. Page likely real;
+ *   we can't disprove existence. Caller should still hand-verify.
+ *
+ * Anything else (404, 410, 5xx, network/DNS error, timeout) → broken.
+ */
+export function isReachable(status: number | string): boolean {
+  if (typeof status !== 'number') return false;
+  if (status >= 200 && status < 400) return true;
+  return status === 401 || status === 403 || status === 429;
+}
+
+/**
+ * Validate a list of URLs concurrently. Returns only the broken ones.
+ * Pass an empty array → empty array (no work).
+ */
+export async function validateUrls(
+  entries: UrlCheckEntry[],
+  opts: ValidateOptions = {},
+): Promise<UrlCheckResult[]> {
+  const concurrency = opts.concurrency ?? 6;
+  const timeoutMs = opts.timeoutMs ?? 10000;
+  const broken: UrlCheckResult[] = [];
+  const queue = [...entries];
+
+  async function worker() {
+    while (queue.length) {
+      const item = queue.shift();
+      if (!item) break;
+      const status = await checkOne(item.url, timeoutMs);
+      if (!isReachable(status)) broken.push({ url: item.url, context: item.context, status });
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, entries.length) }, () => worker());
+  await Promise.all(workers);
+  return broken;
+}
+
+async function checkOne(url: string, timeoutMs: number): Promise<number | string> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  const headers = { 'User-Agent': 'Mozilla/5.0 (sgai url-check)' };
+  try {
+    let resp = await fetch(url, { method: 'HEAD', redirect: 'follow', signal: controller.signal, headers });
+    // Some servers reject HEAD; retry as GET.
+    if (resp.status === 405 || resp.status === 501) {
+      resp = await fetch(url, { method: 'GET', redirect: 'follow', signal: controller.signal, headers });
+    }
+    return resp.status;
+  } catch (err) {
+    const e = err as { name?: string };
+    return `ERR:${e.name ?? 'fetch'}`;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/**
+ * Walk a prospect-shaped object and pull every sourceUrl from the standard
+ * voices fields. Handy default for voices/people-style data; other
+ * pipelines should hand-build their own UrlCheckEntry[] list.
+ */
+export function collectVoicesSourceUrls(
+  data: Record<string, unknown>,
+  fields: readonly string[] = ['signatureWork', 'notableQuotes', 'speakingRecord', 'externalRoles'],
+): UrlCheckEntry[] {
+  const out: UrlCheckEntry[] = [];
+  for (const k of fields) {
+    const arr = data[k];
+    if (!Array.isArray(arr)) continue;
+    arr.forEach((entry, i) => {
+      if (entry && typeof entry === 'object') {
+        const url = (entry as Record<string, unknown>).sourceUrl;
+        if (typeof url === 'string' && /^https?:\/\//i.test(url)) {
+          out.push({ url, context: `${k}[${i}].sourceUrl` });
+        }
+      }
+    });
+  }
+  return out;
+}

--- a/scripts/voices/prospect-stubs.mjs
+++ b/scripts/voices/prospect-stubs.mjs
@@ -27,9 +27,13 @@
 //   node scripts/voices/prospect-stubs.mjs status
 //     Print review queue status (pending / ready / applied counts).
 //
-//   node scripts/voices/prospect-stubs.mjs apply <id>
+//   node scripts/voices/prospect-stubs.mjs apply <id> [--skip-url-check]
 //     Read a "ready" prospect file and print a TypeScript snippet to
 //     stdout. Paste into the matching person record in people.ts.
+//     Before printing, every sourceUrl is HEAD-checked; any 4xx/5xx
+//     (other than 401/403/429 bot-walls) blocks the apply with exit 2.
+//     This is the front-line defense against LLM-fabricated URLs whose
+//     format looks right but the page never existed (e.g. spkr4563 IDs).
 //
 //   node scripts/voices/prospect-stubs.mjs sync-from-people [<id> ...] [--dry-run]
 //     Reverse-sync: copy live curated fields (signatureWork / notableQuotes
@@ -335,9 +339,10 @@ async function cmdSyncFromPeople(args) {
 async function cmdApply(args) {
   const id = args[0];
   if (!id) {
-    console.error('Usage: apply <person-id>');
+    console.error('Usage: apply <person-id> [--skip-url-check]');
     process.exit(1);
   }
+  const skipUrlCheck = args.includes('--skip-url-check');
   const filePath = join(PROSPECTS_DIR, `${id}.json`);
   if (!existsSync(filePath)) {
     console.error(`No prospect file at ${filePath}`);
@@ -356,11 +361,91 @@ async function cmdApply(args) {
     process.exit(1);
   }
 
+  if (!skipUrlCheck) {
+    const urls = collectSourceUrls(data, fields);
+    if (urls.length > 0) {
+      process.stderr.write(`Validating ${urls.length} sourceUrl(s) — pass --skip-url-check to bypass…\n`);
+      const broken = await validateUrls(urls);
+      if (broken.length > 0) {
+        console.error(
+          `\nBlocking apply: ${broken.length} sourceUrl(s) are unreachable (4xx/5xx/network error).\n` +
+            `LLM-fabricated URLs (correct format, fake ID) and dead links are the typical causes.\n` +
+            `Fix the prospect JSON or pass --skip-url-check if you've manually verified.\n`,
+        );
+        for (const b of broken) console.error(`  ${b.status}  ${b.url}`);
+        process.exit(2);
+      }
+      process.stderr.write('All sourceUrls reachable.\n');
+    }
+  }
+
   console.log(`// Patch for person id="${id}" — paste these fields into the matching record in src/data/people.ts:\n`);
   for (const k of fields) {
     console.log(`    ${k}: ${stringifyTs(data[k])},`);
   }
   console.log(`\n// After pasting, set this prospect's status to "applied" in ${filePath}.`);
+}
+
+// Walk the populated fields and pull every sourceUrl that's actually a string.
+function collectSourceUrls(data, fields) {
+  const urls = [];
+  for (const k of fields) {
+    for (const entry of data[k]) {
+      if (entry && typeof entry.sourceUrl === 'string' && /^https?:\/\//i.test(entry.sourceUrl)) {
+        urls.push({ field: k, url: entry.sourceUrl });
+      }
+    }
+  }
+  return urls;
+}
+
+// HEAD-then-GET fallback (some servers reject HEAD). Treat 2xx/3xx and 401/403/429
+// as "reachable enough" — bot-walls and auth gates don't mean 404. Anything else
+// (including network errors) flags as broken.
+async function validateUrls(urls, { concurrency = 6, timeoutMs = 10000 } = {}) {
+  const broken = [];
+  const queue = [...urls];
+  async function worker() {
+    while (queue.length) {
+      const item = queue.shift();
+      const status = await checkOne(item.url, timeoutMs);
+      if (!isReachable(status)) broken.push({ url: item.url, status });
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, urls.length) }, worker));
+  return broken;
+}
+
+async function checkOne(url, timeoutMs) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    let resp = await fetch(url, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { 'User-Agent': 'Mozilla/5.0 (sgai prospect-stubs validator)' },
+    });
+    if (resp.status === 405 || resp.status === 501) {
+      resp = await fetch(url, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: controller.signal,
+        headers: { 'User-Agent': 'Mozilla/5.0 (sgai prospect-stubs validator)' },
+      });
+    }
+    return resp.status;
+  } catch (err) {
+    return `ERR:${err.name || 'fetch'}`;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function isReachable(status) {
+  if (typeof status !== 'number') return false;
+  if (status >= 200 && status < 400) return true;
+  return status === 401 || status === 403 || status === 429;
 }
 
 // Format a JSON value as TS-friendly source (single quotes, trailing commas).

--- a/src/data/people.ts
+++ b/src/data/people.ts
@@ -566,14 +566,6 @@ export const people: Person[] = [
         date: '2025',
         sourceUrl: 'https://www.scai.gov.sg/2025/participants-of-scai-2025/mohan-kankanhalli/',
       },
-      {
-        event: 'Singapore FinTech Festival',
-        eventEn: 'Singapore FinTech Festival',
-        role: 'Speaker',
-        roleEn: 'Speaker',
-        date: '2025',
-        sourceUrl: 'https://www.fintechfestival.sg/speakers/spkr4563-prof-mohan-kankanhalli',
-      },
     ],
     externalRoles: [
       {
@@ -581,14 +573,12 @@ export const people: Person[] = [
         roleEn: 'Fellow',
         organization: '新加坡国家科学院（SNAS）',
         organizationEn: 'Singapore National Academy of Science (SNAS)',
-        sourceUrl: 'https://www.weforum.org/people/mohan-kankanhalli/',
       },
       {
         role: 'IEEE Fellow',
         roleEn: 'IEEE Fellow',
         organization: 'IEEE',
         organizationEn: 'IEEE',
-        sourceUrl: 'https://www.weforum.org/people/mohan-kankanhalli/',
       },
     ],
   },
@@ -1123,7 +1113,6 @@ export const people: Person[] = [
         descriptionEn:
           "Phase 2 joint labs with Singapore Airlines and SIAEC developing AI-driven solutions for airline value-chain operations; driven by Lim's SERC.",
         since: '2025',
-        sourceUrl: 'https://asianaviation.com/astar-sia-siaec-sign-deals-for-cabins-ai/',
       },
       {
         title: 'A*STAR IHPC（前任执行长）',


### PR DESCRIPTION
## Summary

- 删除 [voices/mohan-kankanhalli](https://sgai.md/voices/mohan-kankanhalli/) 上的 4 条假/死链（用户报告 404 触发的全量 audit）
- 新增 [scripts/lib/url-check.ts](scripts/lib/url-check.ts) — 通用 URL 可达性校验 lib
- [scripts/voices/prospect-stubs.mjs](scripts/voices/prospect-stubs.mjs) `apply` 命令前置 HEAD 校验，4xx/5xx → exit 2；`--skip-url-check` 留逃生口
- [CLAUDE.md](CLAUDE.md) 新增规则 #6「sourceUrl 真实性约定」，对标 i18n 双字段那条作为顶层硬规则

## Root cause

[c574e54](../commit/c574e54)（2026-05-03 voices backfill）由 LLM 批量回填 19 个三无人物时，凭训练记忆/格式推断**编造**了部分 URL。模式正确（如 `fintechfestival.sg/speakers/spkr<NUMBER>-<slug>`）但 ID 是虚构的。voices pipeline 与 hansard / videos 不同，没有上游 API 提供 URL ground-truth，LLM 幻觉无任何防御。

被清理的 4 条：

| 文件 | URL | 处置 |
|---|---|---|
| `people.ts:575` | `fintechfestival.sg/...spkr4563...` (404) | 整条 speakingRecord 删除（事件本身没发生） |
| `people.ts:1126` | `asianaviation.com/astar-sia-siaec-...` (404) | 删 sourceUrl 保留 entry（合作真实） |
| `people.ts:584,591` | `weforum.org/people/mohan-...` (403/伪 404) | 删 sourceUrl 保留 entries |

## Defense

1. `validateUrls()` HEAD-then-GET 校验，treat 401/403/429 as reachable bot-walls
2. CLAUDE.md 规则 #6 强制：未来"LLM 补脑"型管线必须复用同一校验

## Test plan

- [x] 自测：`apply` 注入 spkr4563 假 URL → exit 2 正确 block
- [x] 自测：清理后的 mohan-kankanhalli prospect → exit 0 正常通过
- [x] zh + EN voices/mohan-kankanhalli 页面 curl 已无残留
- [x] `npm run check` 通过（只剩 cron 自己的 prettier warnings，与本 PR 无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)