### PR TITLE
data(manus): NDRC vetoes Meta–Manus acquisition (2026-04-27)

### DIFF
--- a/src/components/timeline/TimelinePage.astro
+++ b/src/components/timeline/TimelinePage.astro
@@ -24,6 +24,7 @@ const TAG_EN: Record<string, string> = {
   产业: 'Industry',
   创新: 'Innovation',
   标准: 'Standards',
+  数据主权: 'Data Sovereignty',
 };
 const tagText = (tag: string) => (lang === 'en' ? (TAG_EN[tag] ?? tag) : tag);
 

--- a/src/data/fieldnotes.ts
+++ b/src/data/fieldnotes.ts
@@ -96,6 +96,7 @@ export const fieldNotes: FieldNote[] = [
           'EDB 深度介入：提前与人力部沟通、拆分人员批次',
           '预期是要放弃一部分原有团队',
           '结论：正常公司走正常流程，成功率更高。特殊协助只出现在"已经没有第二种选择"的情况下',
+          '后续验证（2026-04-27）：中国国家发改委以国安为由叫停 Meta 对 Manus 的 20 亿美元收购，划三条红线（技术主权/数据主权/国家安全）。EDB 当时所说的「时间窗口压力」与「迁出核心团队」事后被证实是源自来源国监管走向——单凭迁注册地不足以脱离来源国管辖，这是「Singapore washing」策略的第一次被显式驳回。',
         ],
         pointsEn: [
           'EDB raised Manus on its own initiative, but made clear that it was a special case.',
@@ -103,6 +104,7 @@ export const fieldNotes: FieldNote[] = [
           'EDB engaged deeply: coordinating in advance with the Ministry of Manpower and breaking the relocation into batches.',
           'The expectation was that part of the original team would have to be left behind.',
           'Bottom line: ordinary companies should follow the ordinary process, where success rates are higher. Special assistance is reserved for situations where there is no alternative.',
+          'Follow-up (27 April 2026): China\'s NDRC blocked Meta\'s US$2B acquisition of Manus on national-security grounds, drawing three red lines (technology sovereignty, data sovereignty, national security). The "time-window pressure" and the "core-team relocation" EDB referenced were, in hindsight, downstream of source-country regulatory direction — re-domiciling alone is not enough to exit source-country jurisdiction, and the "Singapore washing" play was, for the first time, explicitly rejected.',
         ],
       },
       {

--- a/src/data/startups.ts
+++ b/src/data/startups.ts
@@ -380,14 +380,15 @@ export interface Exit {
 export const exits: Exit[] = [
   {
     name: 'Manus',
-    description: 'AI Agent 平台',
-    descriptionEn: 'AI agent platform',
-    acquirer: 'Meta',
-    acquirerEn: 'Meta',
-    amount: '$2B+',
+    description: 'AI Agent 平台（Butterfly Effect 旗下）',
+    descriptionEn: 'AI agent platform (operated by Butterfly Effect)',
+    acquirer: 'Meta（已被中国 NDRC 否决）',
+    acquirerEn: 'Meta (blocked by China NDRC)',
+    amount: '$2B (blocked)',
     year: 2025,
-    note: '新加坡最大 AI 收购案',
-    noteEn: "Singapore's largest AI acquisition",
+    note: '2025-12 宣布拟收购，2026-04-27 中国国家发改委以国家安全为由叫停（AI 领域首例外资并购否决，三条红线：技术主权 / 数据主权 / 国家安全）。新加坡作为「AI 离岸中转枢纽」战略首次被来源国监管显式划红线。',
+    noteEn:
+      'Acquisition announced December 2025; blocked by China\'s NDRC on 27 April 2026 on national-security grounds — the first foreign acquisition vetoed in the AI sector, citing three red lines: technology sovereignty, data sovereignty, and national security. Singapore\'s "AI offshore transit hub" strategy was, for the first time, explicitly red-lined by a source-country regulator.',
   },
   {
     name: 'AIDA Technologies',

--- a/src/data/timeline.ts
+++ b/src/data/timeline.ts
@@ -29,6 +29,19 @@ export const timelineEvents: TimelineEvent[] = [
     tags: ['人才', '国际'],
   },
   {
+    id: 'evt-2026-manus-blocked',
+    year: 2026,
+    date: '2026-04-27',
+    title: 'Meta–Manus 收购被中国 NDRC 否决：「Singapore washing」红线划定',
+    titleEn: 'China Blocks Meta–Manus Acquisition: A Red Line Against "Singapore Washing"',
+    description:
+      '4 月 27 日，中国国家发展和改革委员会（NDRC）正式叫停 Meta 对 Manus 的 20 亿美元收购，援引"国家安全"理由——这是中国首例以国安为由否决 AI 领域外资并购。NDRC 划定三条红线：技术主权、数据主权、国家安全。Manus 母公司 Butterfly Effect 由肖弘、季逸超 2022 年在中国创立，2025 年中将总部迁至新加坡（约 40 名核心技术员从北京搬迁，120 人团队多数被裁），由新加坡 Butterfly Effect 实体接管海外业务。Meta 于 2025 年 12 月宣布收购。2026 年 1 月中国监管启动审查，3 月末肖弘与季逸超被约谈并限制出境。事件直接挑战新加坡作为「AI 离岸中转枢纽」的战略叙事——多家国际媒体（Asia Times、Foreign Policy）将此案定义为「Singapore washing 的极限」，意指仅靠迁注册地无法绕开来源国监管。对 sgai 既有数据点的影响：startups.ts `exits[]` 中 Manus 由「已完成 $2B exit」调整为被否；fieldnotes.ts EDB「Manus 是特例」一节获得后续验证。',
+    descriptionEn:
+      'On 27 April, China\'s National Development and Reform Commission (NDRC) formally blocked Meta\'s US$2B acquisition of Manus on national-security grounds — the first time China has vetoed a foreign AI acquisition under that rationale. NDRC drew three red lines: technology sovereignty, data sovereignty, and national security. Manus\'s parent Butterfly Effect was founded in China in 2022 by Xiao Hong and Ji Yichao, then relocated its HQ to Singapore in mid-2025 (~40 core technical staff moved from Beijing while most of the 120-person team was laid off), with the Singapore Butterfly Effect entity taking over operations outside China. Meta announced the acquisition in December 2025. Chinese regulators opened a review in January 2026; by late March, Xiao and Ji had been summoned to NDRC and barred from leaving China. The case directly challenges Singapore\'s strategic narrative as an "AI offshore transit hub" — international press (Asia Times, Foreign Policy) framed it as "the limits of Singapore washing," meaning that re-domiciling alone cannot escape source-country oversight. Impact on existing sgai data: in startups.ts the Manus entry in `exits[]` is reframed from a completed $2B exit to a blocked deal; the fieldnotes "Manus is a special case" section gains follow-up confirmation.',
+    tags: ['治理', '产业', '国际', '数据主权'],
+    relatedPostSlugs: [],
+  },
+  {
     id: 'evt-2026-sc42-plenary',
     year: 2026,
     date: '2026-04-20',

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-export const SITE_VERSION = '0.9.2';
+export const SITE_VERSION = '0.9.3';
 export const SITE_UPDATED = '2026-05-03';


### PR DESCRIPTION
## Summary

Records the **first time China has blocked an AI-sector foreign acquisition under national-security review** — the 2026-04-27 NDRC veto of Meta's US$2B acquisition of Manus, a deal anchored on Manus's mid-2025 relocation of HQ from Beijing to Singapore.

Directly relevant to sgai's data-sovereignty narrative: this is the first time the "AI offshore transit hub" play (so-called *"Singapore washing"*) has been explicitly red-lined by a source-country regulator.

## Changes

| File | Change |
|---|---|
| `src/data/timeline.ts` | New event `evt-2026-manus-blocked` (2026-04-27, zh + en, tags: 治理/产业/国际/数据主权) |
| `src/data/startups.ts` | Manus `exits[]` reframed: completed → blocked; bilingual notes name NDRC + three red lines |
| `src/data/fieldnotes.ts` | Follow-up bullet appended under EDB "Manus is a special case" — confirming the EDB-cited "regulatory time-window pressure" was upstream of the NDRC veto |
| `src/components/timeline/TimelinePage.astro` | `TAG_EN += { 数据主权: 'Data Sovereignty' }` |
| `src/version.ts` | 0.9.2 → 0.9.3 |

## Why this matters for sgai

- Reframes existing data: Manus had been in the repo as Singapore's largest AI exit ($2B / Meta / 2025). That fact is now stale and misleading.
- Adds a missing primary-event milestone the timeline page needed.
- Validates the EDB fieldnote: what looked like a "special case" in Feb-2026 is now sourced to a concrete external-regulatory force (NDRC).
- Hansard had **zero** Manus mentions for the 2026-04-08 sitting (vetoed 19 days later). Worth re-scanning post-PR for the May/June sitting once the political chatter catches up.

## Sources

- [Asia Times — China's Manus AI case sets red lines to bar 'Singapore washing'](https://asiatimes.com/2026/05/chinas-manus-ai-case-sets-red-lines-to-bar-singapore-washing/)
- [Foreign Policy — Why Did China Block Meta-Manus AI Deal?](https://foreignpolicy.com/2026/04/28/china-blocks-ai-meta-manus-deal-national-security/)
- [ICLG — China blocks Meta's $2 billion Manus deal](https://iclg.com/news/23803-china-blocks-meta-s-2-billion-manus-deal-in-ai-security-clampdown/amp)
- [D'Andrea & Partners — Meta–Manus Deal Prohibited (legal analysis)](https://www.dandreapartners.com/meta-manus-deal-prohibited-national-security-review-halts-a-foreign-acquisition-in-ai-sector-for-the-first-time/)
- [Indrastra — The End of 'Singapore-Washing'?](https://www.indrastra.com/2026/04/the-end-of-singapore-washing-china.html)

## Test plan

- [x] `npm run check` — astro / eslint / prettier / graph all pass
- [x] `npm run build` — 2013 pages built clean
- [x] `node scripts/i18n-check.mjs` — 0 CJK residue on EN pages
- [x] Preview verified: `/timeline/`, `/en/timeline/`, `/startups/`, `/en/startups/`, `/fieldnotes/`, `/en/fieldnotes/` all render the new content with bilingual parity

## Follow-up (separate PR)

- Deep-dive blog post — "Singapore washing 的极限" (sgai's first reactive piece on Manus)
- Hansard pipeline 5 bug fixes + auto-PR upgrade (range too small, content not scanned, state semantics — separate work, tracked in next refresh task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)