### PR TITLE
typography: migrate remaining hardcoded text-* utilities to t-* scale

### DIFF
--- a/src/components/benchmarking/RegionProfile.astro
+++ b/src/components/benchmarking/RegionProfile.astro
@@ -174,7 +174,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
     </section>
 
     <section class="callout-note rounded-lg p-5 mb-10">
-      <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-3">{labels.oneLineRead}</h2>
+      <h2 class="t-h3 text-gray-900 dark:text-white mb-3">{labels.oneLineRead}</h2>
       <p class="text-gray-800 dark:text-gray-200 leading-[1.85]">{overview || labels.oneLineReadFallback}</p>
     </section>
 
@@ -182,9 +182,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
       detail ? (
         <>
           <section class="mb-10">
-            <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-4">
-              {labels.coreStrategiesHeading}
-            </h2>
+            <h2 class="t-h3 text-gray-900 dark:text-white mb-4">{labels.coreStrategiesHeading}</h2>
             <div class="space-y-3">
               {detail.strategies.map((strategyItem, index) => (
                 <a
@@ -204,9 +202,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
           </section>
 
           <section class="mb-10">
-            <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-4">
-              {labels.investmentHeading}
-            </h2>
+            <h2 class="t-h3 text-gray-900 dark:text-white mb-4">{labels.investmentHeading}</h2>
             <div class="grid gap-3">
               {detail.investment.map((item, index) => (
                 <a
@@ -237,9 +233,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
           </section>
 
           <section class="mb-10">
-            <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-3">
-              {labels.governanceHeading}
-            </h2>
+            <h2 class="t-h3 text-gray-900 dark:text-white mb-3">{labels.governanceHeading}</h2>
             <p class="text-gray-700 dark:text-gray-300 leading-[1.85]">
               {isEn ? detail.governanceEn || detail.governance : detail.governance}
             </p>
@@ -247,9 +241,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
 
           <section class="mb-10 grid md:grid-cols-2 gap-5">
             <div>
-              <h2 class="font-serif text-xl font-semibold text-green-700 dark:text-green-300 mb-3">
-                {labels.strengthsHeading}
-              </h2>
+              <h2 class="t-h3 text-green-700 dark:text-green-300 mb-3">{labels.strengthsHeading}</h2>
               <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
                 {strengthsList.map((item) => (
                   <li>• {item}</li>
@@ -257,9 +249,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
               </ul>
             </div>
             <div>
-              <h2 class="font-serif text-xl font-semibold text-red-700 dark:text-red-300 mb-3">
-                {labels.weaknessesHeading}
-              </h2>
+              <h2 class="t-h3 text-red-700 dark:text-red-300 mb-3">{labels.weaknessesHeading}</h2>
               <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
                 {weaknessesList.map((item) => (
                   <li>• {item}</li>
@@ -269,7 +259,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
           </section>
 
           <section class="mb-10">
-            <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-4">{labels.keyHeading}</h2>
+            <h2 class="t-h3 text-gray-900 dark:text-white mb-4">{labels.keyHeading}</h2>
             <div class="grid md:grid-cols-2 gap-5">
               <div class="bg-surface border border-subtle rounded-lg p-4">
                 <h3 class="font-semibold mb-3">{labels.keyInitiatives}</h3>
@@ -307,7 +297,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
           </section>
 
           <section class="mb-10">
-            <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-3">{labels.sourcesHeading}</h2>
+            <h2 class="t-h3 text-gray-900 dark:text-white mb-3">{labels.sourcesHeading}</h2>
             <ul class="space-y-1 text-sm text-gray-500 dark:text-gray-400">
               {sourcesList.map((source) => (
                 <li>• {source}</li>
@@ -324,7 +314,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
     }
 
     <section class="mb-10">
-      <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-4">{labels.relatedHeading}</h2>
+      <h2 class="t-h3 text-gray-900 dark:text-white mb-4">{labels.relatedHeading}</h2>
       <div class="flex flex-wrap gap-3">
         <a
           href={benchmarkRoot}
@@ -348,7 +338,7 @@ const sourcesList = (isEn && detail?.sourcesEn?.length ? detail.sourcesEn : deta
     </section>
 
     <section class="mb-10">
-      <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-4">{labels.continueHeading}</h2>
+      <h2 class="t-h3 text-gray-900 dark:text-white mb-4">{labels.continueHeading}</h2>
       <div class="grid gap-3 md:grid-cols-2">
         {
           relatedRegions.map((item) => (

--- a/src/components/data/CommunityOpenSourceProjectDetail.astro
+++ b/src/components/data/CommunityOpenSourceProjectDetail.astro
@@ -111,7 +111,7 @@ const facts = [
             <div class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
               {isEn ? metric.labelEn || metric.label : metric.label}
             </div>
-            <div class="text-2xl font-bold text-primary">{isEn ? metric.valueEn || metric.value : metric.value}</div>
+            <div class="t-stat text-primary">{isEn ? metric.valueEn || metric.value : metric.value}</div>
             {(isEn ? metric.noteEn || metric.note : metric.note) && (
               <div class="text-xs text-muted mt-1">{isEn ? metric.noteEn || metric.note : metric.note}</div>
             )}

--- a/src/components/data/OpenSourceProjectDetail.astro
+++ b/src/components/data/OpenSourceProjectDetail.astro
@@ -95,7 +95,7 @@ const facts = [
             <div class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
               {isEn ? metric.labelEn || metric.label : metric.label}
             </div>
-            <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">
+            <div class="t-stat text-blue-600 dark:text-blue-400">
               {isEn ? metric.valueEn || metric.value : metric.value}
             </div>
             {(isEn ? metric.noteEn || metric.note : metric.note) && (

--- a/src/components/debates/DebatesIndex.astro
+++ b/src/components/debates/DebatesIndex.astro
@@ -630,7 +630,7 @@ const typeMixLabel = Object.entries(DEBATE_STATS.byType)
       <div class="grid grid-cols-2 gap-3 md:grid-cols-4">
         <div class="rounded-lg border border-subtle bg-gray-50 p-3 dark:bg-slate-800/60">
           <div class="text-xs text-gray-500">{L.total}</div>
-          <div class="mt-1 text-2xl font-bold text-blue-600">{DEBATE_STATS.total}</div>
+          <div class="mt-1 t-stat text-blue-600">{DEBATE_STATS.total}</div>
         </div>
         <div class="rounded-lg border border-subtle bg-gray-50 p-3 dark:bg-slate-800/60">
           <div class="text-xs text-gray-500">{L.years}</div>

--- a/src/components/home/HomePage.astro
+++ b/src/components/home/HomePage.astro
@@ -201,7 +201,7 @@ const debateTitle = (d: (typeof debates)[number]) => pickLocalized<string>(d, 't
   <div class="max-w-5xl mx-auto px-4 sm:px-6 py-5">
     <div class="grid grid-cols-2 md:grid-cols-4 gap-6 text-sm">
       <div>
-        <div class="text-2xl font-serif font-semibold text-gray-900 dark:text-white tabular-nums">
+        <div class="t-stat text-gray-900 dark:text-white">
           {totalPolicies}
         </div>
         <div class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider mt-1">
@@ -209,13 +209,13 @@ const debateTitle = (d: (typeof debates)[number]) => pickLocalized<string>(d, 't
         </div>
       </div>
       <div>
-        <div class="text-2xl font-serif font-semibold text-gray-900 dark:text-white tabular-nums">{totalDebates}</div>
+        <div class="t-stat text-gray-900 dark:text-white">{totalDebates}</div>
         <div class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider mt-1">
           {t(lang, 'freshnessDebates')}
         </div>
       </div>
       <div>
-        <div class="text-2xl font-serif font-semibold text-gray-900 dark:text-white tabular-nums">
+        <div class="t-stat text-gray-900 dark:text-white">
           {totalLeverItems}
         </div>
         <div class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider mt-1">
@@ -223,7 +223,7 @@ const debateTitle = (d: (typeof debates)[number]) => pickLocalized<string>(d, 't
         </div>
       </div>
       <div>
-        <div class="text-2xl font-serif font-semibold text-gray-900 dark:text-white tabular-nums">
+        <div class="t-stat text-gray-900 dark:text-white">
           {SITE_UPDATED}
         </div>
         <div class="text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider mt-1">
@@ -238,7 +238,7 @@ const debateTitle = (d: (typeof debates)[number]) => pickLocalized<string>(d, 't
 <section class="py-12 md:py-16 border-t border-subtle">
   <div class="max-w-5xl mx-auto px-4 sm:px-6">
     <div class="flex items-baseline justify-between mb-2">
-      <h2 class="font-serif text-2xl md:text-3xl font-semibold text-gray-900 dark:text-white">
+      <h2 class="t-h2 text-gray-900 dark:text-white">
         {t(lang, 'recentDebatesSection')}
       </h2>
       <a

--- a/src/pages/[lang]/benchmarking/index.astro
+++ b/src/pages/[lang]/benchmarking/index.astro
@@ -65,11 +65,11 @@ function insightHref(index: number): string {
       <dl class="grid gap-3 sm:grid-cols-3 md:grid-cols-1">
         <div class="rounded-lg border border-subtle bg-surface p-4">
           <dt class="text-xs uppercase tracking-wider text-muted">{isZh ? '案例档案' : 'Case profiles'}</dt>
-          <dd class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">{benchmarkCases.length}</dd>
+          <dd class="mt-1 t-stat text-gray-900 dark:text-white">{benchmarkCases.length}</dd>
         </div>
         <div class="rounded-lg border border-subtle bg-surface p-4">
           <dt class="text-xs uppercase tracking-wider text-muted">{isZh ? '地区背景' : 'Region profiles'}</dt>
-          <dd class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">{regionPages.length}</dd>
+          <dd class="mt-1 t-stat text-gray-900 dark:text-white">{regionPages.length}</dd>
         </div>
         <div class="rounded-lg border border-subtle bg-surface p-4">
           <dt class="text-xs uppercase tracking-wider text-muted">{isZh ? '档案更新' : 'Profiles updated'}</dt>

--- a/src/pages/[lang]/policies/index.astro
+++ b/src/pages/[lang]/policies/index.astro
@@ -29,19 +29,19 @@ const totalPolicies = categories.reduce((sum, cat) => sum + cat.policies.length,
         <p class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
           {t(lang, 'policiesStatProfiles')}
         </p>
-        <p class="text-2xl font-bold text-primary">{totalPolicies}</p>
+        <p class="t-stat text-primary">{totalPolicies}</p>
       </div>
       <div class="bg-surface rounded-lg border border-subtle p-4">
         <p class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
           {t(lang, 'policiesStatCategories')}
         </p>
-        <p class="text-2xl font-bold text-primary">{categories.length}</p>
+        <p class="t-stat text-primary">{categories.length}</p>
       </div>
       <div class="bg-surface rounded-lg border border-subtle p-4">
         <p class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
           {t(lang, 'policiesStatFormat')}
         </p>
-        <p class="text-2xl font-bold text-primary">{t(lang, 'policiesStatFormatValue')}</p>
+        <p class="t-stat text-primary">{t(lang, 'policiesStatFormatValue')}</p>
       </div>
     </div>
 

--- a/src/pages/[lang]/talent/[id].astro
+++ b/src/pages/[lang]/talent/[id].astro
@@ -189,7 +189,7 @@ const resolvedRelated = relatedProgrammes.map((r) => ({
     }
 
     <section class="callout-muted rounded-lg mb-10">
-      <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-3">
+      <h2 class="t-h3 text-gray-900 dark:text-white mb-3">
         {isZh ? '官方来源' : 'Official Source'}
       </h2>
       <a

--- a/src/pages/[lang]/talent/index.astro
+++ b/src/pages/[lang]/talent/index.astro
@@ -54,9 +54,7 @@ const statusClasses: Record<TalentStatusTone, string> = {
                     <p class="text-xs uppercase tracking-[0.14em] text-muted font-semibold mb-1">
                       {pickLocalized(prog, 'category', lang)}
                     </p>
-                    <h3 class="font-serif text-xl font-semibold leading-snug text-gray-900 dark:text-white">
-                      {pickLocalized(prog, 'name', lang)}
-                    </h3>
+                    <h3 class="t-h3 text-gray-900 dark:text-white">{pickLocalized(prog, 'name', lang)}</h3>
                     {isZh && <p class="text-sm text-muted mt-1">{prog.nameEn}</p>}
                     {!isZh && prog.shortName && <p class="text-sm text-muted mt-1">{prog.shortName}</p>}
                   </div>

--- a/src/pages/benchmarking/index.astro
+++ b/src/pages/benchmarking/index.astro
@@ -56,11 +56,11 @@ function insightHref(index: number): string {
       <dl class="grid gap-3 sm:grid-cols-3 md:grid-cols-1">
         <div class="rounded-lg border border-subtle bg-surface p-4">
           <dt class="text-xs uppercase tracking-wider text-muted">Case profiles</dt>
-          <dd class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">{benchmarkCases.length}</dd>
+          <dd class="mt-1 t-stat text-gray-900 dark:text-white">{benchmarkCases.length}</dd>
         </div>
         <div class="rounded-lg border border-subtle bg-surface p-4">
           <dt class="text-xs uppercase tracking-wider text-muted">Region profiles</dt>
-          <dd class="mt-1 text-2xl font-bold text-gray-900 dark:text-white">{regionPages.length}</dd>
+          <dd class="mt-1 t-stat text-gray-900 dark:text-white">{regionPages.length}</dd>
         </div>
         <div class="rounded-lg border border-subtle bg-surface p-4">
           <dt class="text-xs uppercase tracking-wider text-muted">Profiles updated</dt>

--- a/src/pages/policies/index.astro
+++ b/src/pages/policies/index.astro
@@ -25,19 +25,19 @@ const totalPolicies = categories.reduce((sum, cat) => sum + cat.policies.length,
         <p class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
           {t(lang, 'policiesStatProfiles')}
         </p>
-        <p class="text-2xl font-bold text-primary">{totalPolicies}</p>
+        <p class="t-stat text-primary">{totalPolicies}</p>
       </div>
       <div class="bg-surface rounded-lg border border-subtle p-4">
         <p class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
           {t(lang, 'policiesStatCategories')}
         </p>
-        <p class="text-2xl font-bold text-primary">{categories.length}</p>
+        <p class="t-stat text-primary">{categories.length}</p>
       </div>
       <div class="bg-surface rounded-lg border border-subtle p-4">
         <p class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1">
           {t(lang, 'policiesStatFormat')}
         </p>
-        <p class="text-2xl font-bold text-primary">{t(lang, 'policiesStatFormatValue')}</p>
+        <p class="t-stat text-primary">{t(lang, 'policiesStatFormatValue')}</p>
       </div>
     </div>
 

--- a/src/pages/talent/[id].astro
+++ b/src/pages/talent/[id].astro
@@ -149,7 +149,7 @@ const schema = {
     }
 
     <section class="callout-muted rounded-lg mb-10">
-      <h2 class="font-serif text-xl font-semibold text-gray-900 dark:text-white mb-3">Official Source</h2>
+      <h2 class="t-h3 text-gray-900 dark:text-white mb-3">Official Source</h2>
       <a
         href={programme.profile.sourceUrl}
         target="_blank"

--- a/src/pages/talent/index.astro
+++ b/src/pages/talent/index.astro
@@ -45,9 +45,7 @@ const statusClasses: Record<TalentStatusTone, string> = {
                   </div>
                   <div class="min-w-0">
                     <p class="text-xs uppercase tracking-[0.14em] text-muted font-semibold mb-1">{prog.categoryEn}</p>
-                    <h3 class="font-serif text-xl font-semibold leading-snug text-gray-900 dark:text-white">
-                      {prog.nameEn}
-                    </h3>
+                    <h3 class="t-h3 text-gray-900 dark:text-white">{prog.nameEn}</h3>
                     {prog.shortName && <p class="text-sm text-muted mt-1">{prog.shortName}</p>}
                   </div>
                 </div>


### PR DESCRIPTION
## Typography Retrospective — 2026-05-10 (1-week post-introduction)

Type-scale utilities were introduced on 2026-05-03. This PR cleans up all remaining hardcoded `text-* font-*` combos found during the retrospective audit.

---

### 1. Baseline usage counts (post-migration)

| Utility | Files | Occurrences |
|---------|-------|-------------|
| `.t-display` | 32 | 32 |
| `.t-h1` | 6 | 6 |
| `.t-h2` | 15 | 35 |
| `.t-h3` | 44 | 151 |
| `.t-stat` | 16 | 40 |
| `.t-lead` | 10 | 10 |

> Counts above reflect the *post-migration* state in this PR. Pre-PR: `t-h2` was 14 files/34 occ, `t-h3` was 40 files/137 occ, `t-stat` was 12 files/23 occ.

---

### 2. Escaped hardcoded typography (found → migrated in this PR)

**`font-serif text-xl font-semibold` → `t-h3` (14 occurrences)**

| File | Line(s) | Note |
|------|---------|------|
| `src/components/benchmarking/RegionProfile.astro` | 177, 185, 207, 240, 250, 260, 272, 310, 327, 351 | Section h2s; green/red strength-weakness h2s preserved color classes |
| `src/pages/talent/index.astro` | 48 | Card h3; `leading-snug` dropped (included in `t-h3`) |
| `src/pages/[lang]/talent/index.astro` | 57 | Same |
| `src/pages/talent/[id].astro` | 152 | "Official Source" section h2 |
| `src/pages/[lang]/talent/[id].astro` | 192 | Same |

**`text-2xl font-serif font-semibold tabular-nums` → `t-stat` (4 occurrences)**

| File | Lines | Note |
|------|-------|------|
| `src/components/home/HomePage.astro` | 204, 212, 218, 226 | Freshness strip stat numbers; `tabular-nums` dropped (included in `t-stat`) |

**`font-serif text-2xl md:text-3xl font-semibold` → `t-h2` (1 occurrence)**

| File | Line | Note |
|------|------|------|
| `src/components/home/HomePage.astro` | 241 | "Recent debates" section heading |

**`text-2xl font-bold text-primary` → `t-stat text-primary` (6 occurrences)**

| File | Lines |
|------|-------|
| `src/pages/policies/index.astro` | 28, 34, 40 |
| `src/pages/[lang]/policies/index.astro` | 32, 38, 44 |

**`mt-1 text-2xl font-bold text-gray-900 dark:text-white` → `mt-1 t-stat text-gray-900 dark:text-white` (4 occurrences)**

| File | Lines |
|------|-------|
| `src/pages/benchmarking/index.astro` | 59, 63 |
| `src/pages/[lang]/benchmarking/index.astro` | 68, 72 |

**Component stat cards → `t-stat` (3 occurrences)**

| File | Line | Pattern |
|------|------|---------|
| `src/components/data/OpenSourceProjectDetail.astro` | 98 | `text-2xl font-bold text-blue-600 dark:text-blue-400` |
| `src/components/data/CommunityOpenSourceProjectDetail.astro` | 114 | `text-2xl font-bold text-primary` |
| `src/components/debates/DebatesIndex.astro` | 633 | `mt-1 text-2xl font-bold text-blue-600` |

**Total migrated: 32 occurrences across 13 files.**

---

### 3. Recent-commit drift (files modified since 2026-05-03)

Git log shows nearly every `.astro` file was touched in the past week (initial site stand-up). The escaped occurrences in §2 **are** the drift — they were introduced in the same window as the type-scale utilities and were simply missed during the initial pass. No additional new-page drift was found beyond what §2 already covers.

---

### 4. Skipped / flagged (intentional non-migrations)

| File | Pattern | Reason skipped |
|------|---------|----------------|
| `src/components/widgets/Footer.astro:41` | `inline-block font-bold text-xl` | Logo link, not a heading. Adding `font-serif md:text-2xl leading-snug` would change the brand wordmark treatment. Not in scope. |
| `src/components/widgets/BlogHighlightedPosts.astro:42` | `text-3xl font-bold ... font-heading sm:text-4xl` | Uses `font-heading` (not `font-serif`) and `sm:` breakpoint (not `md:`). No t-* utility matches this pattern. On the intentional-exclusion list boundary. |

---

### 5. Verification

```
npm run check
```
Result: **0 errors, 0 warnings, 93/93 tests pass.**

https://claude.ai/code/session_017siNeurXTArTy5vWf37RPV

---
_Generated by [Claude Code](https://claude.ai/code/session_017siNeurXTArTy5vWf37RPV)_