### PR TITLE
chore(format): prettier --write tracker/methodology.astro (drift from #33)

### DIFF
--- a/src/pages/tracker/methodology.astro
+++ b/src/pages/tracker/methodology.astro
@@ -140,8 +140,8 @@ const metadata = {
         <strong>We acknowledge limits</strong> — public data may diverge from internal corporate or government reality
       </li>
       <li>
-        <strong>Challenges welcome</strong> — outdated numbers, biased interpretations, better metrics: file an issue or email
-        us
+        <strong>Challenges welcome</strong> — outdated numbers, biased interpretations, better metrics: file an issue or
+        email us
       </li>
     </ul>
 


### PR DESCRIPTION
## Summary

- `main` is currently failing `npm run check` (specifically `check:prettier`) on `src/pages/tracker/methodology.astro`.
- Root cause: [#33](https://github.com/meltflake/sgai/pull/33) bundled a Prettier 3.6 → 3.8 bump. 3.8's line-break heuristic re-wraps one `<li>` here, but the actual reformat didn't make it into the commit even though [b399081](https://github.com/meltflake/sgai/commit/b399081)'s message claimed it did.
- Fix: literal `npx prettier --write src/pages/tracker/methodology.astro`. 2 insertions / 2 deletions, whitespace only, no semantic change.

## Test plan

- [x] `npx prettier --check src/pages/tracker/methodology.astro` → passes
- [x] `npm run check` → green (0 errors, 93 lib tests pass)
- [x] Diff scope: 1 file, 2/2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)