### PR TITLE
feat(voices): TS-native auto-PR pipeline for MDDI speeches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ scripts/refresh/talent/data/
 scripts/refresh/startups/data/
 scripts/refresh/tracker/data/
 scripts/refresh/benchmarking/data/
+scripts/refresh/voices/data/
 
 # i18n translation cache (sha256-keyed claude haiku output)
 scripts/i18n/data/

--- a/scripts/auto_update.py
+++ b/scripts/auto_update.py
@@ -4,10 +4,11 @@ sgai 数据自动更新 — 统一包装脚本（registry-driven）。
 
 读取 scripts/refresh/registry.json，按 --schedule 过滤要跑的管线。
 每条管线分两类：
-  - python-builtin: hansard / videos / voices（旧三条，保留原 in-process 调用）
-  - tsx: 新管线（policies / ecosystem / github-stars / levers / legal-ai），
-    通过 `npx tsx <script>` 子进程执行；脚本在末尾 print 一行 JSON 报告，
-    被本脚本捕获并汇入邮件。
+  - python-builtin: hansard / videos（保留原 in-process scan-only 调用）
+  - tsx: 新管线（voices / policies / ecosystem / github-stars / levers /
+    legal-ai / talent / startups / tracker / benchmarking），通过
+    `npx tsx <script>` 子进程执行；脚本在末尾 print 一行 JSON 报告，
+    被本脚本捕获并汇入通知。
 
 用法:
   python auto_update.py                              # 运行所有管线
@@ -144,24 +145,9 @@ def run_videos(logger) -> dict:
 
 
 # ── 管线 2: MDDI 演讲 ────────────────────────────────────────────────────────
-def run_voices(logger) -> dict:
-    import importlib
-
-    mod = importlib.import_module("voices.01_scan_mddi")
-    speeches = mod.scan_mddi(exclude_existing=True)
-    logger.info(f"MDDI 扫描完成: {len(speeches)} 条演讲")
-    return {
-        "count": len(speeches),
-        "items": [
-            {
-                "date": s["date"],
-                "title": s["title"],
-                "speaker": s["speaker"],
-                "url": s["url"],
-            }
-            for s in speeches[:10]
-        ],
-    }
+# Removed: voices is now type=tsx + mode=auto-pr (scripts/refresh/voices/run.ts).
+# The tsx pipeline handles scan + fetch + translate + emit + commit + PR end-to-end
+# and is dispatched by run_tsx_pipeline() below.
 
 
 # ── 管线 3: 国会辩论 (轻量 API 扫描) ─────────────────────────────────────────
@@ -315,20 +301,8 @@ def compose_email(results: dict, errors: list[str], elapsed: float) -> tuple[str
         elif not r.get("error"):
             lines.append("<p>无新内容</p>")
 
-    if "voices" in results:
-        r = results["voices"]
-        lines.append(f"<h3>MDDI 演讲: {r.get('count', 0)} 条新发现</h3>")
-        if r.get("items"):
-            lines.append("<ul>")
-            for s in r["items"]:
-                speaker = s.get("speaker") or "?"
-                title = s.get("title", "?")
-                url = s.get("url")
-                title_html = f"<a href='{url}'>{title}</a>" if url else title
-                lines.append(f"  <li>[{s.get('date','?')}] {speaker}: {title_html}</li>")
-            lines.append("</ul>")
-        elif not r.get("error"):
-            lines.append("<p>无新内容</p>")
+    # voices is now a tsx auto-pr pipeline (scripts/refresh/voices/run.ts) —
+    # its result is rendered by the generic tsx block at the bottom, not here.
 
     if "hansard" in results:
         r = results["hansard"]
@@ -344,7 +318,7 @@ def compose_email(results: dict, errors: list[str], elapsed: float) -> tuple[str
 
     # New tsx pipelines block (no items detail; PR link is the action).
     for pid, r in results.items():
-        if pid in ("videos", "voices", "hansard"):
+        if pid in ("videos", "hansard"):
             continue
         c = r.get("count", 0) or 0
         f = r.get("failures", 0) or 0
@@ -543,8 +517,6 @@ def main():
             if ptype == "python-builtin":
                 if pid == "videos":
                     results["videos"] = run_videos(logger)
-                elif pid == "voices":
-                    results["voices"] = run_voices(logger)
                 elif pid == "hansard":
                     hansard_result = run_hansard(state, logger)
                     results["hansard"] = hansard_result
@@ -571,13 +543,13 @@ def main():
 
     # ── 通知（GitHub Issue 取代 SMTP）──
     # 新管线（type=tsx, mode=auto-pr）已经各自开了 PR + assign @me，不需重复通知。
-    # 这里只为 scan-only 旧管线（hansard / videos / voices）和失败开 issue。
+    # 这里只为 scan-only 旧管线（hansard / videos）和失败开 issue。
     try:
         from auto_update_config import NOTIFY_IF_NO_NEW
     except ImportError:
         NOTIFY_IF_NO_NEW = False
 
-    scan_only_pids = {"hansard", "videos", "voices"}
+    scan_only_pids = {"hansard", "videos"}
     scan_only_results = {pid: r for pid, r in results.items() if pid in scan_only_pids}
     scan_only_total = sum(r.get("count", 0) or 0 for r in scan_only_results.values())
     should_notify = scan_only_total > 0 or NOTIFY_IF_NO_NEW or errors

--- a/scripts/refresh/registry.json
+++ b/scripts/refresh/registry.json
@@ -26,11 +26,13 @@
     },
     {
       "id": "voices",
-      "type": "python-builtin",
+      "type": "tsx",
       "schedule": "weekly",
       "label": "MDDI speeches",
-      "description": "MDDI sitemap scan. Existing pipeline.",
-      "mode": "scan-only-email"
+      "description": "MDDI sitemap scan + page fetch + Claude haiku translation (zh paragraphs, zh+en tldr) + trilingual title/event/speakerTitle. Emits to voices.ts mddiSpeeches[] + speech-transcripts.ts speechTranscripts map.",
+      "script": "scripts/refresh/voices/run.ts",
+      "args": ["--limit=3"],
+      "mode": "auto-pr"
     },
     {
       "id": "github-stars",

--- a/scripts/refresh/voices/emit.ts
+++ b/scripts/refresh/voices/emit.ts
@@ -1,0 +1,346 @@
+// scripts/refresh/voices/emit.ts
+// ────────────────────────────────────────────────────────────────────────
+// Insert new MDDI speech rows into two data files:
+//
+//   1. src/data/voices.ts → mddiSpeeches[] gets a new record per speech
+//      (full trilingual fields: title/titleEn/titleJa, event/eventEn/eventJa,
+//      speakerTitle/speakerTitleEn/speakerTitleJa, addedAt today).
+//
+//   2. src/data/speech-transcripts.ts → speechTranscripts map gets one
+//      entry per speech (paragraphs zh + en, tldr zh + en, fetchedAt,
+//      sourceUrl, source 'mddi-newsroom').
+//
+// Strategy: line-based insertion before the closing `];` / `};`. We do
+// NOT regenerate the full map — existing entries (incl. Task A's NANA
+// work) stay byte-identical. This is the same approach as
+// policies/emit.ts.
+//
+// Anti-hallucination guards (CLAUDE.md rule #6 + rule #7):
+//   - sourceUrl must be absolute http(s) and live under mddi.gov.sg.
+//   - titleEn, title, titleJa must all be non-empty (i18n triple-sync rule).
+//   - addedAt: today is set on every emitted mddiSpeeches record.
+//
+// Post-write i18n guard:
+//   - findUnpairedFields baseline-vs-after on both files. Rollback only
+//     on REGRESSION (existing baseline issues aren't this pipeline's
+//     responsibility, mirroring policies/emit.ts).
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { findUnpairedFields } from '../../lib/i18n-pair.ts';
+import type { FetchedSpeech } from './fetch.ts';
+import type { TranslatedSpeech } from './translate.ts';
+
+const VOICES_FILE = resolve('src/data/voices.ts');
+const TRANSCRIPTS_FILE = resolve('src/data/speech-transcripts.ts');
+
+export interface EmittableSpeech {
+  speechId: string;
+  sourceUrl: string;
+  pageTitle: string;
+  publishedDate: string | null;
+  paragraphsEn: string[];
+  paragraphsZh: string[];
+  tldrEn: string[];
+  tldrZh: string[];
+  titleZh: string;
+  titleEn: string;
+  titleJa: string;
+  eventEn: string;
+  eventZh: string;
+  eventJa: string;
+  speaker: string;
+  speakerTitleEn: string;
+  speakerTitleZh: string;
+  speakerTitleJa: string;
+  translatedAt: string;
+  translationSource: 'claude' | 'manual';
+  translationModel?: string;
+}
+
+export interface EmitResult {
+  voicesFile: string;
+  transcriptsFile: string;
+  recordsAdded: number;
+  skipped: Array<{ speechId: string; reason: string }>;
+}
+
+export function combineForEmit(
+  fetched: FetchedSpeech,
+  translated: TranslatedSpeech,
+  enriched: {
+    titleZh: string;
+    titleEn: string;
+    titleJa: string;
+    eventEn: string;
+    eventZh: string;
+    eventJa: string;
+    speaker: string;
+    speakerTitleZh: string;
+    speakerTitleEn: string;
+    speakerTitleJa: string;
+  }
+): EmittableSpeech {
+  return {
+    speechId: fetched.speechId,
+    sourceUrl: fetched.sourceUrl,
+    pageTitle: fetched.title,
+    publishedDate: fetched.publishedDate,
+    paragraphsEn: translated.paragraphsEn,
+    paragraphsZh: translated.paragraphs,
+    tldrEn: translated.tldrEn,
+    tldrZh: translated.tldr,
+    titleZh: enriched.titleZh,
+    titleEn: enriched.titleEn,
+    titleJa: enriched.titleJa,
+    eventEn: enriched.eventEn,
+    eventZh: enriched.eventZh,
+    eventJa: enriched.eventJa,
+    speaker: enriched.speaker,
+    speakerTitleEn: enriched.speakerTitleEn,
+    speakerTitleZh: enriched.speakerTitleZh,
+    speakerTitleJa: enriched.speakerTitleJa,
+    translatedAt: translated.translatedAt,
+    translationSource: translated.translationSource,
+    translationModel: translated.translationModel,
+  };
+}
+
+function escapeBacktick(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+function escapeQuote(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+// Strip irregular whitespace before serialising paragraphs into the TS
+// data file: NBSP / zero-width / RTL marks would survive Prettier and
+// trip ESLint's no-irregular-whitespace downstream. Built from \u
+// escapes so this source file itself stays clean.
+// Same set as scripts/voices/03_generate_ts.py.
+const IRREGULAR_WS_CHARS =
+  ' ' + // NBSP
+  ' ' + // Ogham space mark
+  '᠎' + // Mongolian vowel separator
+  ' -​' + // en quad..zero-width space
+  '‌-‏' + // ZWNJ / ZWJ / LRM / RLM
+  ' ' + // narrow no-break space
+  ' ' + // medium math space
+  '⁠' + // word joiner
+  '　' + // ideographic space
+  '﻿'; // ZWNBSP / BOM
+const IRREGULAR_WS_RE = new RegExp(`[${IRREGULAR_WS_CHARS}]`, 'g');
+
+function cleanParagraph(s: string): string {
+  return s.replace(IRREGULAR_WS_RE, ' ').replace(/[ \t]+/g, ' ').trim();
+}
+
+function tsArray(items: string[], indent: number): string {
+  if (!items.length) return '[]';
+  const pad = ' '.repeat(indent);
+  const inner = items
+    .map((s) => `${pad}  \`${escapeBacktick(s)}\``)
+    .join(',\n');
+  return `[\n${inner},\n${pad}]`;
+}
+
+function formatTranscriptEntry(s: EmittableSpeech): string {
+  const paragraphsZh = s.paragraphsZh.map(cleanParagraph).filter(Boolean);
+  const paragraphsEn = s.paragraphsEn.map(cleanParagraph).filter(Boolean);
+  const tldrZh = s.tldrZh.map(cleanParagraph).filter(Boolean);
+  const tldrEn = s.tldrEn.map(cleanParagraph).filter(Boolean);
+  const fetchedAt = new Date().toISOString().slice(0, 10);
+  const lines: string[] = [];
+  lines.push(`  '${escapeQuote(s.speechId)}': {`);
+  lines.push(`    speechId: \`${escapeBacktick(s.speechId)}\`,`);
+  lines.push(`    sourceUrl: \`${escapeBacktick(s.sourceUrl)}\`,`);
+  lines.push(`    sourceLanguage: 'en',`);
+  lines.push(`    fetchedAt: \`${escapeBacktick(fetchedAt)}\`,`);
+  lines.push(`    source: 'mddi-newsroom',`);
+  lines.push(`    paragraphs: ${tsArray(paragraphsZh, 4)},`);
+  lines.push(`    paragraphsEn: ${tsArray(paragraphsEn, 4)},`);
+  if (tldrZh.length) lines.push(`    tldr: ${tsArray(tldrZh, 4)},`);
+  if (tldrEn.length) lines.push(`    tldrEn: ${tsArray(tldrEn, 4)},`);
+  lines.push(`    translatedAt: \`${escapeBacktick(s.translatedAt)}\`,`);
+  lines.push(`    translationSource: '${s.translationSource}',`);
+  if (s.translationModel) {
+    lines.push(`    translationModel: '${escapeQuote(s.translationModel)}',`);
+  }
+  lines.push('  },');
+  return lines.join('\n');
+}
+
+function formatVoicesEntry(s: EmittableSpeech, today: string): string {
+  // Field order matches existing mddiSpeeches entries (titleEn first).
+  const lines: string[] = [];
+  lines.push('  {');
+  lines.push(`    titleEn: '${escapeQuote(s.titleEn)}',`);
+  lines.push(`    title: '${escapeQuote(s.titleZh)}',`);
+  lines.push(`    titleJa: '${escapeQuote(s.titleJa)}',`);
+  lines.push(`    speaker: '${escapeQuote(s.speaker)}',`);
+  lines.push(`    speakerTitle: '${escapeQuote(s.speakerTitleZh)}',`);
+  lines.push(`    speakerTitleJa: '${escapeQuote(s.speakerTitleJa)}',`);
+  lines.push(`    speakerTitleEn: '${escapeQuote(s.speakerTitleEn)}',`);
+  const date =
+    s.publishedDate && /^\d{4}-\d{2}-\d{2}$/.test(s.publishedDate)
+      ? s.publishedDate
+      : today;
+  lines.push(`    date: '${date}',`);
+  lines.push(`    url: '${escapeQuote(s.sourceUrl)}',`);
+  lines.push(`    eventEn: '${escapeQuote(s.eventEn)}',`);
+  lines.push(`    event: '${escapeQuote(s.eventZh)}',`);
+  lines.push(`    eventJa: '${escapeQuote(s.eventJa)}',`);
+  lines.push(`    addedAt: '${today}',`);
+  lines.push('  },');
+  return lines.join('\n');
+}
+
+function findArrayCloseLine(lines: string[], openMarker: RegExp): number {
+  let openLine = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (openMarker.test(lines[i])) {
+      openLine = i;
+      break;
+    }
+  }
+  if (openLine === -1) throw new Error(`Could not locate opening marker ${openMarker}`);
+  let depth = 0;
+  for (let i = openLine; i < lines.length; i += 1) {
+    const opens = (lines[i].match(/[[{]/g) || []).length;
+    const closes = (lines[i].match(/[\]}]/g) || []).length;
+    depth += opens;
+    depth -= closes;
+    if (depth === 0 && i > openLine) return i;
+  }
+  throw new Error(`Could not find matching close for ${openMarker}`);
+}
+
+function validatePair(
+  before: number,
+  filePath: string,
+  fields: string[]
+): { ok: boolean; afterCount: number } {
+  const afterIssues = findUnpairedFields(filePath, { fields });
+  return { ok: afterIssues.length <= before, afterCount: afterIssues.length };
+}
+
+function appendToVoices(
+  toEmit: EmittableSpeech[],
+  options: { dryRun?: boolean }
+): { added: number; baseline: number; after: number } {
+  if (!existsSync(VOICES_FILE)) throw new Error(`Missing ${VOICES_FILE}`);
+  const original = readFileSync(VOICES_FILE, 'utf8');
+  const lines = original.split('\n');
+  const closeLine = findArrayCloseLine(
+    lines,
+    /^export const mddiSpeeches:\s*MddiSpeech\[\]\s*=\s*\[/
+  );
+  const today = new Date().toISOString().slice(0, 10);
+  const formatted = toEmit.map((s) => formatVoicesEntry(s, today)).join('\n');
+  const updated = [...lines.slice(0, closeLine), formatted, ...lines.slice(closeLine)].join('\n');
+
+  const baseline = findUnpairedFields(VOICES_FILE, {
+    fields: ['title', 'event', 'speakerTitle'],
+  }).length;
+  if (options.dryRun) return { added: toEmit.length, baseline, after: baseline };
+  writeFileSync(VOICES_FILE, updated);
+  const v = validatePair(baseline, VOICES_FILE, ['title', 'event', 'speakerTitle']);
+  if (!v.ok) {
+    writeFileSync(VOICES_FILE, original);
+    throw new Error(
+      `voices.ts i18n pairing regressed: ${baseline} -> ${v.afterCount} unpaired. Rolled back.`
+    );
+  }
+  return { added: toEmit.length, baseline, after: v.afterCount };
+}
+
+function appendToTranscripts(
+  toEmit: EmittableSpeech[],
+  options: { dryRun?: boolean }
+): { added: number; baseline: number; after: number } {
+  if (!existsSync(TRANSCRIPTS_FILE)) throw new Error(`Missing ${TRANSCRIPTS_FILE}`);
+  const original = readFileSync(TRANSCRIPTS_FILE, 'utf8');
+  const lines = original.split('\n');
+  const closeLine = findArrayCloseLine(
+    lines,
+    /^export const speechTranscripts:\s*Record<string,\s*SpeechTranscript>\s*=\s*\{/
+  );
+  const formatted = toEmit.map(formatTranscriptEntry).join('\n');
+  const updated = [...lines.slice(0, closeLine), formatted, ...lines.slice(closeLine)].join('\n');
+
+  const baseline = findUnpairedFields(TRANSCRIPTS_FILE, {
+    fields: ['title', 'description'],
+  }).length;
+  if (options.dryRun) return { added: toEmit.length, baseline, after: baseline };
+  writeFileSync(TRANSCRIPTS_FILE, updated);
+  const v = validatePair(baseline, TRANSCRIPTS_FILE, ['title', 'description']);
+  if (!v.ok) {
+    writeFileSync(TRANSCRIPTS_FILE, original);
+    throw new Error(
+      `speech-transcripts.ts i18n pairing regressed: ${baseline} -> ${v.afterCount} unpaired. Rolled back.`
+    );
+  }
+  return { added: toEmit.length, baseline, after: v.afterCount };
+}
+
+export function emit(
+  speeches: EmittableSpeech[],
+  options: { dryRun?: boolean } = {}
+): EmitResult {
+  const accepted: EmittableSpeech[] = [];
+  const skipped: EmitResult['skipped'] = [];
+  for (const s of speeches) {
+    if (!s.sourceUrl || !/^https?:\/\//.test(s.sourceUrl)) {
+      skipped.push({ speechId: s.speechId, reason: 'missing sourceUrl' });
+      continue;
+    }
+    if (!/mddi\.gov\.sg/.test(s.sourceUrl)) {
+      skipped.push({ speechId: s.speechId, reason: 'sourceUrl not under mddi.gov.sg' });
+      continue;
+    }
+    if (!s.titleEn || !s.titleZh || !s.titleJa) {
+      skipped.push({ speechId: s.speechId, reason: 'missing trilingual title' });
+      continue;
+    }
+    if (!s.eventEn || !s.eventZh || !s.eventJa) {
+      skipped.push({ speechId: s.speechId, reason: 'missing trilingual event' });
+      continue;
+    }
+    if (s.paragraphsEn.length === 0 || s.paragraphsZh.length === 0) {
+      skipped.push({ speechId: s.speechId, reason: 'empty paragraphs' });
+      continue;
+    }
+    accepted.push(s);
+  }
+
+  if (accepted.length === 0) {
+    return {
+      voicesFile: VOICES_FILE,
+      transcriptsFile: TRANSCRIPTS_FILE,
+      recordsAdded: 0,
+      skipped,
+    };
+  }
+
+  // Write transcripts first so a voices-side rollback can undo the
+  // transcript side via the outer-try cleanup below.
+  let priorTranscripts: string | null = null;
+  try {
+    priorTranscripts = readFileSync(TRANSCRIPTS_FILE, 'utf8');
+    appendToTranscripts(accepted, options);
+    appendToVoices(accepted, options);
+  } catch (error) {
+    if (priorTranscripts && !options.dryRun) {
+      writeFileSync(TRANSCRIPTS_FILE, priorTranscripts);
+    }
+    throw error;
+  }
+
+  return {
+    voicesFile: VOICES_FILE,
+    transcriptsFile: TRANSCRIPTS_FILE,
+    recordsAdded: accepted.length,
+    skipped,
+  };
+}

--- a/scripts/refresh/voices/fetch.ts
+++ b/scripts/refresh/voices/fetch.ts
@@ -1,0 +1,257 @@
+// scripts/refresh/voices/fetch.ts
+// ────────────────────────────────────────────────────────────────────────
+// Fetch one MDDI newsroom page and extract:
+//   - h1 title (used for the AI summarizer's title input)
+//   - publishedDate (best-effort)
+//   - English paragraphs[] (main body text, multi-strategy)
+//
+// Strategies ported from scripts/voices/02_fetch_speeches.py
+// BeautifulSoup logic, but implemented with regex over the raw HTML
+// because the repo doesn't ship cheerio / node-html-parser. The MDDI
+// template is stable enough that this is fine; if MDDI ever rebuilds the
+// site we can wrap one of those parsers behind the same interface.
+//
+// CloudFront is sensitive: we send a real desktop UA + standard headers,
+// matching 02_fetch_speeches.py.
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface FetchedSpeech {
+  speechId: string;
+  sourceUrl: string;
+  fetchedAt: string;
+  /** <h1> or og:title; used to seed the AI summarizer. */
+  title: string;
+  /** ISO date if extractable, else null. */
+  publishedDate: string | null;
+  paragraphs: string[];
+}
+
+export interface FetchResult {
+  successes: FetchedSpeech[];
+  failures: Array<{ speechId: string; sourceUrl: string; error: string }>;
+}
+
+const RAW_DIR = resolve('scripts/refresh/voices/data/raw');
+const SPEECHES_DIR = resolve('scripts/refresh/voices/data/speeches');
+
+const REAL_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+const SKIP_SUBSTRINGS = [
+  'Call the 24/7 ScamShield',
+  'ScamShield Helpline',
+  'Subscribe to our newsletter',
+];
+
+const NOISE_LINES = new Set(['***', '.  .  .  .  .', '. . . . .']);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#160;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&rsquo;/g, '’')
+    .replace(/&lsquo;/g, '‘')
+    .replace(/&rdquo;/g, '”')
+    .replace(/&ldquo;/g, '“')
+    .replace(/&hellip;/g, '…')
+    .replace(/&mdash;/g, '—')
+    .replace(/&ndash;/g, '–')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)));
+}
+
+function stripInlineTags(html: string): string {
+  return decodeEntities(html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim());
+}
+
+function extractH1(html: string): string {
+  const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+  if (m) {
+    const text = stripInlineTags(m[1]);
+    if (text) return text;
+  }
+  const og = html.match(/<meta\s+(?:property|name)=["']og:title["']\s+content=["']([^"']+)["']/i);
+  if (og) return decodeEntities(og[1].trim());
+  const t = html.match(/<title>([\s\S]*?)<\/title>/i);
+  if (t) return decodeEntities(t[1].replace(/\s+/g, ' ').trim());
+  return '';
+}
+
+function extractDate(html: string): string | null {
+  const timeTag = html.match(/<time[^>]+datetime=["']([^"']+)["']/i);
+  if (timeTag) return normalizeDate(timeTag[1]);
+  const metas = [
+    /<meta\s+(?:property|name)=["']article:published_time["']\s+content=["']([^"']+)["']/i,
+    /<meta\s+(?:property|name)=["']article:modified_time["']\s+content=["']([^"']+)["']/i,
+    /<meta\s+name=["']publish-date["']\s+content=["']([^"']+)["']/i,
+    /<meta\s+name=["']date["']\s+content=["']([^"']+)["']/i,
+  ];
+  for (const re of metas) {
+    const m = html.match(re);
+    if (m) return normalizeDate(m[1]);
+  }
+  const text = stripInlineTags(html);
+  const inline = text.match(
+    /\b(\d{1,2}\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})\b/
+  );
+  if (inline) return normalizeDate(inline[1]);
+  return null;
+}
+
+function normalizeDate(input: string): string | null {
+  if (/^\d{4}-\d{2}-\d{2}/.test(input)) return input.slice(0, 10);
+  const months: Record<string, string> = {
+    jan: '01', feb: '02', mar: '03', apr: '04', may: '05', jun: '06',
+    jul: '07', aug: '08', sep: '09', oct: '10', nov: '11', dec: '12',
+  };
+  const m = input.toLowerCase().match(/^(\d{1,2})\s+([a-z]+)\s+(\d{4})$/);
+  if (m) {
+    const day = m[1].padStart(2, '0');
+    const month = months[m[2].slice(0, 3)];
+    if (month) return `${m[3]}-${month}-${day}`;
+  }
+  const d = new Date(input);
+  if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+  return null;
+}
+
+/** Walk <p>...</p> blocks inside a given HTML chunk, returning their
+ *  stripped text. Drops empty paragraphs and lines hit by SKIP_SUBSTRINGS
+ *  / NOISE_LINES. */
+function extractPs(chunk: string): string[] {
+  const out: string[] = [];
+  for (const m of chunk.matchAll(/<p[^>]*>([\s\S]*?)<\/p>/gi)) {
+    const text = stripInlineTags(m[1]);
+    if (!text) continue;
+    if (NOISE_LINES.has(text)) continue;
+    if (SKIP_SUBSTRINGS.some((s) => text.includes(s))) continue;
+    if (/^\d{1,2}\s+\w+\s+\d{4}$/.test(text)) continue;
+    out.push(text);
+  }
+  return out;
+}
+
+/** Try to isolate the body container before scanning <p>. MDDI's
+ *  template uses a few distinctive class patterns; we try each. */
+function tryBodyContainer(html: string): string | null {
+  // Strategy 1: div.w-full.overflow-x-auto.break-words
+  const s1 = html.match(
+    /<div[^>]*class=["'][^"']*\bw-full\b[^"']*\boverflow-x-auto\b[^"']*\bbreak-words\b[^"']*["'][\s\S]*?(?=<\/div>\s*<(?:footer|nav|aside))/i
+  );
+  if (s1) return s1[0];
+  // Strategy 2: <main>...</main>
+  const s2 = html.match(/<main\b[\s\S]*?<\/main>/i);
+  if (s2) return s2[0];
+  return null;
+}
+
+export function extractParagraphs(html: string): string[] {
+  const container = tryBodyContainer(html);
+  if (container) {
+    const ps = extractPs(container);
+    if (ps.length >= 5) return ps;
+  }
+  // Fallback: whole document. Strip script/style first to avoid noise.
+  const cleaned = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ');
+  return extractPs(cleaned);
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const resp = await fetch(url, {
+    headers: {
+      'User-Agent': REAL_UA,
+      Accept:
+        'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Sec-Ch-Ua': '"Chromium";v="131", "Not_A Brand";v="24", "Google Chrome";v="131"',
+      'Sec-Ch-Ua-Mobile': '?0',
+      'Sec-Ch-Ua-Platform': '"macOS"',
+      'Sec-Fetch-Dest': 'document',
+      'Sec-Fetch-Mode': 'navigate',
+      'Sec-Fetch-Site': 'none',
+      'Sec-Fetch-User': '?1',
+      'Upgrade-Insecure-Requests': '1',
+    },
+    redirect: 'follow',
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+  return await resp.text();
+}
+
+export interface FetchOptions {
+  /** Sleep between requests (CloudFront is sensitive). Default 1500 ms. */
+  sleepBetweenMs?: number;
+  /** Write the raw page payload to scripts/refresh/voices/data/raw/<id>.html. */
+  saveRaw?: boolean;
+  /** Write the structured speech JSON to data/speeches/<id>.json. Default true. */
+  saveSpeechJson?: boolean;
+}
+
+export async function fetchSpeeches(
+  candidates: Array<{ speechId: string; sourceUrl: string }>,
+  options: FetchOptions = {}
+): Promise<FetchResult> {
+  const sleepBetween = options.sleepBetweenMs ?? 1500;
+  const saveSpeechJson = options.saveSpeechJson ?? true;
+  const successes: FetchedSpeech[] = [];
+  const failures: FetchResult['failures'] = [];
+
+  if (saveSpeechJson) mkdirSync(SPEECHES_DIR, { recursive: true });
+  if (options.saveRaw) mkdirSync(RAW_DIR, { recursive: true });
+
+  for (let i = 0; i < candidates.length; i += 1) {
+    const c = candidates[i];
+    if (i > 0) await sleep(sleepBetween);
+    try {
+      const html = await fetchHtml(c.sourceUrl);
+      if (options.saveRaw) {
+        writeFileSync(`${RAW_DIR}/${c.speechId}.html`, html);
+      }
+      const paragraphs = extractParagraphs(html);
+      if (paragraphs.length === 0) {
+        failures.push({
+          speechId: c.speechId,
+          sourceUrl: c.sourceUrl,
+          error: 'no-paragraphs',
+        });
+        continue;
+      }
+      const record: FetchedSpeech = {
+        speechId: c.speechId,
+        sourceUrl: c.sourceUrl,
+        fetchedAt: new Date().toISOString().slice(0, 10),
+        title: extractH1(html),
+        publishedDate: extractDate(html),
+        paragraphs,
+      };
+      if (saveSpeechJson) {
+        writeFileSync(
+          `${SPEECHES_DIR}/${c.speechId}.json`,
+          `${JSON.stringify(record, null, 2)}\n`
+        );
+      }
+      successes.push(record);
+    } catch (error) {
+      failures.push({
+        speechId: c.speechId,
+        sourceUrl: c.sourceUrl,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { successes, failures };
+}

--- a/scripts/refresh/voices/run.ts
+++ b/scripts/refresh/voices/run.ts
@@ -1,0 +1,365 @@
+// scripts/refresh/voices/run.ts
+// ────────────────────────────────────────────────────────────────────────
+// Orchestrator for the MDDI voices refresh pipeline.
+//
+// Flow:
+//   1. Read existing mddiSpeeches[].url + speechTranscripts keys (dedup set).
+//   2. scan() → candidate URLs from MDDI sitemap, filtered to AI speeches.
+//   3. fetch() → page <h1> + paragraphs[] per candidate.
+//   4. translate() → zh paragraphs + bilingual (zh + en) 4-7 bullet tldr.
+//   5. enrich() → trilingual title + event + speaker title (uses
+//      lib/translate.ts en→zh + en→ja + scripts/refresh/voices/sources
+//      SPEAKER_MAP).
+//   6. emit() → splice new mddiSpeeches + speechTranscripts entries into
+//      src/data/voices.ts + src/data/speech-transcripts.ts with i18n
+//      baseline-vs-after rollback guard.
+//   7. autoCommit() + pushAndOpenPR() → branch + commit + PR via gh.
+//
+// CLI flags:
+//   --dry-run         Skip fetch/translate/emit/commit/push. Scan + report only.
+//   --limit=N         Cap candidates (default 3 to keep PRs small).
+//   --no-commit       Run scan + fetch + translate + emit; stop before commit.
+//   --no-push         Run autoCommit but skip push + PR.
+//   --force           Bypass translation cache (re-translate even when cached).
+
+import { resolve } from 'node:path';
+
+import { loadState, saveState } from '../../lib/state.ts';
+import { autoCommit, pushAndOpenPR, buildPRBody } from '../../lib/auto-commit.ts';
+import { translateBatch } from '../../lib/translate.ts';
+import {
+  scan,
+  readExistingSpeechUrls,
+  readExistingSpeechIds,
+  type VoicesCandidate,
+} from './scan.ts';
+import { fetchSpeeches, type FetchedSpeech } from './fetch.ts';
+import { translateSpeeches, type TranslatedSpeech } from './translate.ts';
+import { combineForEmit, emit, type EmittableSpeech } from './emit.ts';
+import { speakerFromSlug } from './sources.ts';
+
+interface CliFlags {
+  dryRun: boolean;
+  limit: number;
+  noCommit: boolean;
+  noPush: boolean;
+  force: boolean;
+}
+
+const ZH_CACHE = resolve('scripts/i18n/data/zh-cache');
+const JA_CACHE = resolve('scripts/i18n/data/ja-cache');
+
+function parseFlags(): CliFlags {
+  const argv = process.argv.slice(2);
+  const flagSet = new Set(argv.filter((a) => !a.includes('=')));
+  const limitArg = argv.find((a) => a.startsWith('--limit='));
+  return {
+    dryRun: flagSet.has('--dry-run'),
+    limit: limitArg ? Number(limitArg.split('=')[1]) : 3,
+    noCommit: flagSet.has('--no-commit'),
+    noPush: flagSet.has('--no-push'),
+    force: flagSet.has('--force'),
+  };
+}
+
+/** Extract event name from a speech titleEn. Patterns ported from
+ *  scripts/voices/01_scan_mddi.py extract_event(). Returns '' when no
+ *  reliable extraction is possible — caller falls back to the full title. */
+function extractEventEn(titleEn: string): string {
+  const patterns = [
+    /(?:at|for)\s+(?:the\s+)?(.+?)(?:\s*$|\s*\|)/i,
+    /(?:keynote|opening|closing)\s+(?:address|remarks|speech)\s+.*?at\s+(?:the\s+)?(.+?)(?:\s*$)/i,
+  ];
+  for (const p of patterns) {
+    const m = titleEn.match(p);
+    if (!m) continue;
+    let event = m[1].trim();
+    event = event.replace(/\s+on\s+\d{1,2}\s+\w+$/i, '').trim();
+    event = event.replace(/\s*\d{4}\s*$/, '').trim();
+    if (event.length > 5) return event;
+  }
+  return '';
+}
+
+function uniqueBy<T>(arr: T[], keyFn: (v: T) => string): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const v of arr) {
+    const k = keyFn(v);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(v);
+  }
+  return out;
+}
+
+async function enrichTrilingual(
+  fetched: FetchedSpeech[],
+  translated: TranslatedSpeech[]
+): Promise<EmittableSpeech[]> {
+  // Pair fetched ↔ translated by speechId.
+  const tMap = new Map(translated.map((t) => [t.speechId, t]));
+
+  // Step 1: derive titleEn + eventEn + speaker. titleEn defaults to the
+  // page <h1>; eventEn is regex-extracted; speaker comes from SPEAKER_MAP
+  // (slug lookup) and the page <h1> fallback.
+  const partials = fetched.map((f) => {
+    const translatedSpeech = tMap.get(f.speechId);
+    const titleEn = f.title || humaniseSlug(f.speechId);
+    const eventEn = extractEventEn(titleEn) || titleEn;
+    const speakerInfo = speakerFromSlug(f.speechId);
+    return {
+      fetched: f,
+      translatedSpeech,
+      titleEn,
+      eventEn,
+      speakerName: speakerInfo.name,
+      speakerTitleEn: speakerInfo.titleEn,
+      speakerTitleZh: speakerInfo.titleZh,
+      speakerTitleJa: speakerInfo.titleJa,
+    };
+  });
+
+  // Step 2: batch-translate titleEn/eventEn into zh + ja so we minimise
+  // the number of LLM round-trips.
+  const titles = partials.map((p) => p.titleEn);
+  const events = partials.map((p) => p.eventEn);
+  const speakerTitlesEn = partials.map((p) => p.speakerTitleEn);
+
+  const [titlesZh, titlesJa, eventsZh, eventsJa, speakerTitlesZh, speakerTitlesJa] =
+    await Promise.all([
+      translateBatch(titles, { direction: 'en→zh', cacheDir: ZH_CACHE }),
+      translateBatch(titles, { direction: 'en→ja', cacheDir: JA_CACHE }),
+      translateBatch(events, { direction: 'en→zh', cacheDir: ZH_CACHE }),
+      translateBatch(events, { direction: 'en→ja', cacheDir: JA_CACHE }),
+      // Speaker title: only translate empty (SPEAKER_MAP miss) values to
+      // avoid clobbering the canonical map. Empty strings still get
+      // translated by callers downstream — we'll skip empty entries.
+      translateBatch(
+        speakerTitlesEn.map((s) => s || 'Speaker'),
+        { direction: 'en→zh', cacheDir: ZH_CACHE }
+      ),
+      translateBatch(
+        speakerTitlesEn.map((s) => s || 'Speaker'),
+        { direction: 'en→ja', cacheDir: JA_CACHE }
+      ),
+    ]);
+
+  const out: EmittableSpeech[] = [];
+  for (let i = 0; i < partials.length; i += 1) {
+    const p = partials[i];
+    const t = p.translatedSpeech;
+    if (!t) continue;
+    const speakerTitleZh = p.speakerTitleZh || speakerTitlesZh[i];
+    const speakerTitleJa = p.speakerTitleJa || speakerTitlesJa[i];
+    out.push(
+      combineForEmit(p.fetched, t, {
+        titleZh: titlesZh[i],
+        titleEn: p.titleEn,
+        titleJa: titlesJa[i],
+        eventEn: p.eventEn,
+        eventZh: eventsZh[i],
+        eventJa: eventsJa[i],
+        speaker: p.speakerName,
+        speakerTitleZh,
+        speakerTitleEn: p.speakerTitleEn || speakerTitlesEn[i],
+        speakerTitleJa,
+      })
+    );
+  }
+  return out;
+}
+
+function humaniseSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((part) => (part.length > 0 ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(' ');
+}
+
+async function main(): Promise<void> {
+  const flags = parseFlags();
+  const startedAt = Date.now();
+
+  process.stdout.write('\n[voices-refresh] starting\n');
+  if (flags.dryRun) process.stdout.write('  --dry-run: scan only\n');
+
+  const existingUrls = readExistingSpeechUrls();
+  const existingSpeechIds = readExistingSpeechIds();
+  process.stdout.write(
+    `  existing voices.ts urls=${existingUrls.size}, speech-transcripts.ts keys=${existingSpeechIds.size}\n`
+  );
+
+  const state = loadState();
+
+  // 1. Scan.
+  const scanResult = await scan({
+    state,
+    existingUrls,
+    existingSpeechIds,
+    dryRun: flags.dryRun,
+    limit: flags.limit,
+  });
+
+  process.stdout.write(
+    `  scan: ${scanResult.candidates.length} candidates from ${scanResult.perSource.length} sources\n`
+  );
+  for (const s of scanResult.perSource) {
+    const errMark = s.error ? ` ! ${s.error.slice(0, 80)}` : '';
+    process.stdout.write(`    ${s.domain}: ${s.matched}/${s.checked}${errMark}\n`);
+  }
+
+  if (scanResult.candidates.length === 0) {
+    process.stdout.write('\n[voices-refresh] no new candidates. exiting.\n');
+    saveState(state);
+    return;
+  }
+
+  process.stdout.write('\n  Candidates:\n');
+  for (const c of scanResult.candidates.slice(0, 10)) {
+    process.stdout.write(`    [${c.domain}] ${c.sourceUrl}\n`);
+  }
+
+  if (flags.dryRun) {
+    process.stdout.write('\n[voices-refresh] dry-run complete.\n');
+    return;
+  }
+
+  // 2. Fetch each candidate's page (paragraphs + <h1>).
+  process.stdout.write('\n  Fetching...\n');
+  const fetchResult = await fetchSpeeches(
+    scanResult.candidates.map((c: VoicesCandidate) => ({
+      speechId: c.speechId,
+      sourceUrl: c.sourceUrl,
+    }))
+  );
+  process.stdout.write(
+    `  fetched: ${fetchResult.successes.length}, failures: ${fetchResult.failures.length}\n`
+  );
+  for (const f of fetchResult.failures) {
+    process.stdout.write(`    ! ${f.speechId}: ${f.error.slice(0, 80)}\n`);
+  }
+
+  if (fetchResult.successes.length === 0) {
+    process.stdout.write('\n[voices-refresh] no successful fetches. exiting.\n');
+    return;
+  }
+
+  // 3. Translate paragraphs + tldr.
+  process.stdout.write('\n  Translating...\n');
+  const translateResult = await translateSpeeches(fetchResult.successes, {
+    force: flags.force,
+  });
+  process.stdout.write(
+    `  translated: ${translateResult.translated.length}, failures: ${translateResult.failures.length}\n`
+  );
+  for (const f of translateResult.failures) {
+    process.stdout.write(`    ! ${f.speechId}: ${f.error.slice(0, 80)}\n`);
+  }
+
+  // 4. Enrich → trilingual title + event + speaker title.
+  process.stdout.write('\n  Enriching trilingual fields...\n');
+  const enriched = await enrichTrilingual(
+    fetchResult.successes.filter((f) =>
+      translateResult.translated.some((t) => t.speechId === f.speechId)
+    ),
+    translateResult.translated
+  );
+  process.stdout.write(`  enriched: ${enriched.length}\n`);
+
+  // 5. Dedup safety: a parallel run might race; emit one per speechId.
+  const unique = uniqueBy(enriched, (e) => e.speechId);
+
+  if (unique.length === 0) {
+    process.stdout.write('\n[voices-refresh] nothing to emit. exiting.\n');
+    return;
+  }
+
+  // 6. Emit (with i18n rollback guard).
+  process.stdout.write('\n  Emitting...\n');
+  const emitResult = emit(unique);
+  process.stdout.write(
+    `  added ${emitResult.recordsAdded} records, skipped ${emitResult.skipped.length}\n`
+  );
+  for (const s of emitResult.skipped) {
+    process.stdout.write(`    skipped ${s.speechId}: ${s.reason}\n`);
+  }
+
+  if (emitResult.recordsAdded === 0) {
+    process.stdout.write('\n[voices-refresh] nothing emitted. exiting.\n');
+    return;
+  }
+
+  // 7. Commit.
+  if (flags.noCommit) {
+    process.stdout.write('\n[voices-refresh] --no-commit: stopping after emit.\n');
+    return;
+  }
+  process.stdout.write('\n  Committing...\n');
+  const commit = autoCommit({
+    domain: 'voices',
+    files: [resolve('src/data/voices.ts'), resolve('src/data/speech-transcripts.ts')],
+    message: `data(voices): refresh +${emitResult.recordsAdded} MDDI speeches`,
+    allowDirtyPaths: ['scripts/refresh/voices/data/', 'scripts/i18n/data/'],
+  });
+  process.stdout.write(`  branch: ${commit.branch}\n`);
+  process.stdout.write(`  sha: ${commit.sha}\n`);
+
+  // 8. Push + PR.
+  let prUrl = '';
+  let prNumber = 0;
+  if (!flags.noPush) {
+    process.stdout.write('\n  Pushing + opening PR...\n');
+    const body = buildPRBody({
+      domain: 'voices',
+      diffStat: commit.diffStat,
+      newEntries: unique.map((s) => ({
+        title: `${s.titleEn} (${s.speaker || 'speaker unknown'})`,
+        sourceUrl: s.sourceUrl,
+        confidence: 'high',
+      })),
+      failedSources: [
+        ...fetchResult.failures.map((f) => ({ url: f.sourceUrl, error: f.error })),
+        ...translateResult.failures.map((f) => ({
+          url: f.speechId,
+          error: f.error,
+        })),
+      ],
+      checksPassed: [
+        'i18n-pair (post-emit rollback guard on voices.ts + speech-transcripts.ts)',
+      ],
+    });
+    const prResult = await pushAndOpenPR({
+      branch: commit.branch,
+      title: `[data-refresh] voices: +${emitResult.recordsAdded} MDDI speeches`,
+      body,
+      labels: ['data-refresh', 'voices'],
+    });
+    if (prResult.error) {
+      process.stdout.write(`  ! PR step error: ${prResult.error}\n`);
+    } else if (prResult.pr) {
+      prUrl = prResult.pr.url;
+      prNumber = prResult.pr.number;
+      process.stdout.write(`  PR: ${prUrl}\n`);
+    }
+  }
+
+  saveState(state);
+
+  const elapsed = Math.round((Date.now() - startedAt) / 1000);
+  process.stdout.write('\n[voices-refresh] DONE\n');
+  process.stdout.write(
+    JSON.stringify({
+      domain: 'voices',
+      added: emitResult.recordsAdded,
+      failures: fetchResult.failures.length + translateResult.failures.length,
+      branch: commit.branch,
+      sha: commit.sha,
+      pr_url: prUrl || null,
+      pr_number: prNumber || null,
+      elapsed_seconds: elapsed,
+    }) + '\n'
+  );
+}
+
+await main();

--- a/scripts/refresh/voices/scan.ts
+++ b/scripts/refresh/voices/scan.ts
@@ -1,0 +1,148 @@
+// scripts/refresh/voices/scan.ts
+// ────────────────────────────────────────────────────────────────────────
+// Discover new MDDI AI-speech URLs from the MDDI sitemap.
+//
+// Dedupe against TWO existing sources:
+//   1. mddiSpeeches[].url in src/data/voices.ts (already-known metadata)
+//   2. Existing keys in src/data/speech-transcripts.ts (already-archived
+//      transcripts; their URL was derived from the speechId slug). This
+//      protects against the case where a row exists in voices.ts but the
+//      transcript was added separately, and vice versa.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { listSitemap } from '../../lib/gov-fetch.ts';
+import { type ScanState, getDomainState, setDomainState } from '../../lib/state.ts';
+import { VOICES_SOURCES, isAiSpeechUrl, newsroomSlug, type VoicesSource } from './sources.ts';
+
+export interface VoicesCandidate {
+  sourceUrl: string;
+  /** /newsroom/<slug>/ extracted. Used as speech id key. */
+  speechId: string;
+  domain: string;
+  label: string;
+}
+
+export interface ScanResult {
+  candidates: VoicesCandidate[];
+  perSource: Array<{ domain: string; checked: number; matched: number; error?: string }>;
+}
+
+export interface ScanOptions {
+  state: ScanState;
+  /** URL set extracted from voices.ts mddiSpeeches[].url. */
+  existingUrls: Set<string>;
+  /** Speech id set extracted from speech-transcripts.ts keys. */
+  existingSpeechIds: Set<string>;
+  dryRun?: boolean;
+  limit?: number;
+}
+
+async function scanSource(
+  source: VoicesSource,
+  opts: { existingUrls: Set<string>; existingSpeechIds: Set<string> }
+): Promise<{ found: VoicesCandidate[]; checked: number; error?: string }> {
+  const found = new Map<string, VoicesCandidate>();
+  let checked = 0;
+
+  try {
+    for (const sm of source.sitemapUrls) {
+      const urls = await listSitemap(sm);
+      checked += urls.length;
+      for (const raw of urls) {
+        if (source.urlExcludes?.some((re) => re.test(raw))) continue;
+        if (!source.urlPatterns.some((re) => re.test(raw))) continue;
+        if (!isAiSpeechUrl(raw)) continue;
+        const slug = newsroomSlug(raw);
+        if (!slug) continue;
+        // Normalize trailing slash for dedupe parity with voices.ts entries.
+        const normalized = raw.endsWith('/') ? raw : `${raw}/`;
+        if (opts.existingUrls.has(normalized) || opts.existingUrls.has(raw)) continue;
+        if (opts.existingSpeechIds.has(slug)) continue;
+        if (found.has(slug)) continue;
+        found.set(slug, {
+          sourceUrl: normalized,
+          speechId: slug,
+          domain: source.domain,
+          label: source.label,
+        });
+      }
+    }
+    return { found: [...found.values()], checked };
+  } catch (error) {
+    return {
+      found: [...found.values()],
+      checked,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function scan(options: ScanOptions): Promise<ScanResult> {
+  // Voices state stores the URL set we've already considered. We still
+  // dedupe against the actual data files (canonical), but stash any new
+  // discoveries so a future run-with-state knows what's already on disk.
+  void getDomainState(options.state, 'voices');
+
+  const candidates: VoicesCandidate[] = [];
+  const perSource: ScanResult['perSource'] = [];
+
+  for (const source of VOICES_SOURCES) {
+    const result = await scanSource(source, {
+      existingUrls: options.existingUrls,
+      existingSpeechIds: options.existingSpeechIds,
+    });
+    perSource.push({
+      domain: source.domain,
+      checked: result.checked,
+      matched: result.found.length,
+      error: result.error,
+    });
+    candidates.push(...result.found);
+    if (options.dryRun) break;
+  }
+
+  // Persist seen-URLs for observational use (not required for dedupe).
+  const seen = new Set<string>([
+    ...options.existingUrls,
+    ...candidates.map((c) => c.sourceUrl),
+  ]);
+  setDomainState(options.state, 'voices', { urls: [...seen] });
+
+  if (options.limit) {
+    candidates.length = Math.min(candidates.length, options.limit);
+  }
+
+  return { candidates, perSource };
+}
+
+/** Pull every mddiSpeeches[].url from src/data/voices.ts. Robust to
+ *  field order — we read the file as text and regex the `url: '...'`
+ *  literals inside the mddiSpeeches array block. */
+export function readExistingSpeechUrls(filePath: string = resolve('src/data/voices.ts')): Set<string> {
+  const source = readFileSync(filePath, 'utf8');
+  const blockMatch = source.match(/export const mddiSpeeches[^[]*\[([\s\S]*?)^\];/m);
+  if (!blockMatch) return new Set();
+  const block = blockMatch[1];
+  const urls = new Set<string>();
+  for (const m of block.matchAll(/url:\s*['"]([^'"]+)['"]/g)) urls.add(m[1]);
+  return urls;
+}
+
+/** Pull every speech-id key from src/data/speech-transcripts.ts. Used
+ *  as a second dedupe layer in case a transcript was archived
+ *  out-of-band. */
+export function readExistingSpeechIds(
+  filePath: string = resolve('src/data/speech-transcripts.ts')
+): Set<string> {
+  const source = readFileSync(filePath, 'utf8');
+  const blockMatch = source.match(
+    /export const speechTranscripts:[^=]*=\s*\{([\s\S]*?)\n\};/m
+  );
+  if (!blockMatch) return new Set();
+  const block = blockMatch[1];
+  const ids = new Set<string>();
+  for (const m of block.matchAll(/^\s*['"]([a-z0-9-]+)['"]\s*:\s*\{/gm)) ids.add(m[1]);
+  return ids;
+}

--- a/scripts/refresh/voices/sources.ts
+++ b/scripts/refresh/voices/sources.ts
@@ -1,0 +1,144 @@
+// scripts/refresh/voices/sources.ts
+// ────────────────────────────────────────────────────────────────────────
+// Source registry for the MDDI voices pipeline (AI-related speeches).
+//
+// Single source: MDDI newsroom sitemap. Each candidate URL must:
+//   1. Live under /newsroom/<slug>/
+//   2. Have a slug containing a SPEECH keyword (speech / address / remarks / keynote / transcript)
+//   3. Have a slug containing an AI keyword (see AI_SLUG_PATTERNS)
+//
+// Ported from scripts/voices/01_scan_mddi.py to keep the same filter
+// surface; expanding keywords here also flows back through the same
+// channel cron jobs once this pipeline replaces 01.
+
+export interface VoicesSource {
+  domain: string;
+  label: string;
+  sitemapUrls: string[];
+  /** Slug positive filter: URL must match at least one. */
+  urlPatterns: RegExp[];
+  /** Slug negative filter: URL must not match any. */
+  urlExcludes?: RegExp[];
+}
+
+export const SPEECH_SLUG_PATTERNS: RegExp[] = [
+  /\bspeech\b/,
+  /\baddress\b/,
+  /\bremarks\b/,
+  /\bkeynote\b/,
+  /\btranscript\b/,
+];
+
+export const AI_SLUG_PATTERNS: RegExp[] = [
+  /\bai\b/,
+  /artificial-intelligence/,
+  /data-centre/,
+  /digital-infrastructure/,
+  /smart-nation/,
+  /digital-economy/,
+  /digital-leader/,
+  /ai-festival/,
+  /ai-summit/,
+  /ai-world/,
+  /superai/,
+  /agentic/,
+  /compute/,
+  /quantinuum/,
+  /generative-ai/,
+  /national-ai/,
+  /airtrunk/,
+  /google-cloud/,
+  /microsoft.*ai/,
+  /ai-quickstart/,
+  /ai-research/,
+  /ai-health/,
+  /ai-security/,
+  /ai-centre/,
+  /ai-govern/,
+  /ai-student/,
+  /deepfake/,
+  /machine-learning/,
+  /foundation-model/,
+  /\bllm\b/,
+];
+
+/** Lower-case slug → speaker name + Chinese title + EN title. Mirrors
+ *  scripts/voices/01_scan_mddi.py SPEAKER_MAP; centralized so the emit
+ *  step can populate sibling fields. Keep additions sorted by name. */
+export const SPEAKER_MAP: Record<
+  string,
+  { name: string; titleZh: string; titleEn: string; titleJa: string }
+> = {
+  'janil-puthucheary': {
+    name: 'Janil Puthucheary',
+    titleZh: 'MDDI 前高级政务部长',
+    titleEn: 'Former Senior Minister of State, MDDI',
+    titleJa: 'MDDI 元上級政務部長',
+  },
+  'jasmin-lau': {
+    name: 'Jasmin Lau',
+    titleZh: 'MDDI 政务次长',
+    titleEn: 'Minister of State, MDDI',
+    titleJa: 'MDDI 政務次官',
+  },
+  'josephine-teo': {
+    name: 'Josephine Teo',
+    titleZh: '数码发展及新闻部长',
+    titleEn: 'Minister for Digital Development and Information',
+    titleJa: 'デジタル開発・ニュース相',
+  },
+  'rahayu-mahzam': {
+    name: 'Rahayu Mahzam',
+    titleZh: 'MDDI 政务次长',
+    titleEn: 'Minister of State, MDDI',
+    titleJa: 'MDDI 政務次官',
+  },
+  'tan-kiat-how': {
+    name: 'Tan Kiat How',
+    titleZh: 'MDDI 高级政务部长',
+    titleEn: 'Senior Minister of State, MDDI',
+    titleJa: 'MDDI 上級政務部長',
+  },
+};
+
+export const VOICES_SOURCES: VoicesSource[] = [
+  {
+    domain: 'mddi.gov.sg',
+    label: 'Ministry of Digital Development and Information',
+    sitemapUrls: ['https://www.mddi.gov.sg/sitemap.xml'],
+    urlPatterns: [/\/newsroom\//],
+  },
+];
+
+/** Returns the lower-case /newsroom/<slug>/ extracted from a URL,
+ *  or null if not an MDDI newsroom URL. */
+export function newsroomSlug(url: string): string | null {
+  const m = url.toLowerCase().match(/\/newsroom\/([^/?#]+)/);
+  return m ? m[1] : null;
+}
+
+/** A URL counts as an AI-related speech if its slug matches at least
+ *  one SPEECH_SLUG_PATTERNS and one AI_SLUG_PATTERNS entry. */
+export function isAiSpeechUrl(url: string): boolean {
+  const slug = newsroomSlug(url);
+  if (!slug) return false;
+  if (!SPEECH_SLUG_PATTERNS.some((re) => re.test(slug))) return false;
+  if (!AI_SLUG_PATTERNS.some((re) => re.test(slug))) return false;
+  return true;
+}
+
+/** Look up speaker metadata from a slug; case-insensitive substring match.
+ *  Empty fields when no map entry hits — caller should fall back to AI
+ *  summary or the page <h1>. */
+export function speakerFromSlug(slug: string): {
+  name: string;
+  titleZh: string;
+  titleEn: string;
+  titleJa: string;
+} {
+  const lower = slug.toLowerCase();
+  for (const [key, value] of Object.entries(SPEAKER_MAP)) {
+    if (lower.includes(key)) return value;
+  }
+  return { name: '', titleZh: '', titleEn: '', titleJa: '' };
+}

--- a/scripts/refresh/voices/translate.ts
+++ b/scripts/refresh/voices/translate.ts
@@ -1,0 +1,234 @@
+// scripts/refresh/voices/translate.ts
+// ────────────────────────────────────────────────────────────────────────
+// For each fetched MDDI speech: translate paragraphs to zh and produce a
+// 4-7 bullet bilingual tldr (zh + en).
+//
+// Boundary with hand-curated translations:
+//   - If scripts/voices/data/translations/<id>.json already exists (humans
+//     wrote it, or Task A's NANA work), we preserve it. New fields we
+//     produce here are merged in WITHOUT overwriting existing keys.
+//   - When `force: true` is passed, we re-run translation but still
+//     preserve human-authored markers (translationSource === 'manual').
+//
+// Output schema (scripts/voices/data/translations/<id>.json):
+//   {
+//     "speechId": "...",
+//     "paragraphs": ["...zh..."],
+//     "tldr": ["...zh bullet 1...", "..."],
+//     "tldrEn": ["...en bullet 1...", "..."],
+//     "translatedAt": "YYYY-MM-DD",
+//     "translationSource": "claude" | "manual",
+//     "translationModel": "haiku"
+//   }
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { callLlmJson } from '../../lib/llm.ts';
+import { translateBatch } from '../../lib/translate.ts';
+import type { FetchedSpeech } from './fetch.ts';
+
+export interface TranslatedSpeech {
+  speechId: string;
+  paragraphs: string[];
+  paragraphsEn: string[];
+  tldr: string[];
+  tldrEn: string[];
+  translatedAt: string;
+  translationSource: 'claude' | 'manual';
+  translationModel?: string;
+}
+
+export interface TranslateResult {
+  translated: TranslatedSpeech[];
+  failures: Array<{ speechId: string; error: string }>;
+}
+
+/** Hand-curated translations live here (Task A's NANA work, manual
+ *  backfills). The TS pipeline's emit reads this dir as ground truth. */
+export const TRANSLATIONS_DIR_LEGACY = resolve('scripts/voices/data/translations');
+/** Auto-pipeline writes here. emit.ts reads both dirs (legacy first wins
+ *  per spec: "preserve hand-curated existing ones, including A's NANA work"). */
+export const TRANSLATIONS_DIR_NEW = resolve('scripts/refresh/voices/data/translations');
+
+const ZH_PARAGRAPH_CACHE = resolve('scripts/i18n/data/zh-cache');
+
+interface TldrModelOutput {
+  tldr?: unknown;
+  tldrEn?: unknown;
+  reasonForLowConfidence?: string;
+}
+
+function buildTldrSystemPrompt(): string {
+  return [
+    'You are a research analyst for sgai.md, a Singapore AI policy observatory.',
+    'You read a full speech transcript (English) and produce a structured TL;DR.',
+    '',
+    'Hard requirements:',
+    '1. Output strict JSON. No prose, no markdown.',
+    '2. Return EXACTLY this schema: { "tldr": string[], "tldrEn": string[] }.',
+    '3. Both arrays must have the same length, between 4 and 7 items.',
+    '4. tldrEn[i] and tldr[i] cover the SAME bullet point (en + zh of the same idea).',
+    '5. Each bullet is one full sentence summarising a substantive policy / program / number.',
+    '6. Faithful only. Do not invent figures, dates, names not in the source.',
+    '7. Bullet style: declarative, no first-person, no exhortation, no marketing fluff.',
+    '8. CRITICAL: inside the translated zh bullet TEXT, use FULL-WIDTH Chinese quotes (“ ” or 「 」) — NEVER ASCII straight quotes ("); inside the en bullet TEXT, use curly quotes (“ ”) — NEVER ASCII straight quotes ("). ASCII straight quotes inside the string would break JSON parsing. The only allowed straight quotes are the JSON syntax quotes that delimit each string.',
+  ].join('\n');
+}
+
+async function summarizeTldr(
+  fetched: FetchedSpeech,
+  model: string
+): Promise<{ tldr: string[]; tldrEn: string[] }> {
+  // Cap input length to keep claude haiku happy on long speeches.
+  const body = fetched.paragraphs.slice(0, 60).join('\n\n');
+  const userPrompt =
+    `Speech metadata: ${JSON.stringify({
+      sourceUrl: fetched.sourceUrl,
+      title: fetched.title,
+      publishedDate: fetched.publishedDate,
+    })}\n\n` +
+    'Speech full text follows. Produce the bilingual TL;DR per the system prompt schema.\n\n' +
+    body.slice(0, 16000);
+
+  const out = await callLlmJson<TldrModelOutput>(userPrompt, {
+    systemPrompt: buildTldrSystemPrompt(),
+    model,
+  });
+  if (!Array.isArray(out.tldr) || !out.tldr.every((x) => typeof x === 'string')) {
+    throw new Error(`tldr field malformed: ${JSON.stringify(out).slice(0, 200)}`);
+  }
+  if (!Array.isArray(out.tldrEn) || !out.tldrEn.every((x) => typeof x === 'string')) {
+    throw new Error(`tldrEn field malformed: ${JSON.stringify(out).slice(0, 200)}`);
+  }
+  if (out.tldr.length !== out.tldrEn.length) {
+    throw new Error(
+      `tldr length mismatch: zh=${out.tldr.length} en=${out.tldrEn.length}`
+    );
+  }
+  return { tldr: out.tldr as string[], tldrEn: out.tldrEn as string[] };
+}
+
+function readExistingTranslation(speechId: string): TranslatedSpeech | null {
+  for (const dir of [TRANSLATIONS_DIR_LEGACY, TRANSLATIONS_DIR_NEW]) {
+    const path = `${dir}/${speechId}.json`;
+    if (!existsSync(path)) continue;
+    try {
+      const raw = JSON.parse(readFileSync(path, 'utf8')) as Partial<TranslatedSpeech>;
+      if (!raw || typeof raw !== 'object') continue;
+      const paragraphs = Array.isArray(raw.paragraphs) ? (raw.paragraphs as string[]) : [];
+      const paragraphsEn = Array.isArray(raw.paragraphsEn)
+        ? (raw.paragraphsEn as string[])
+        : [];
+      const tldr = Array.isArray(raw.tldr) ? (raw.tldr as string[]) : [];
+      const tldrEn = Array.isArray(raw.tldrEn) ? (raw.tldrEn as string[]) : [];
+      return {
+        speechId,
+        paragraphs,
+        paragraphsEn,
+        tldr,
+        tldrEn,
+        translatedAt: raw.translatedAt || new Date().toISOString().slice(0, 10),
+        translationSource:
+          raw.translationSource === 'manual' ? 'manual' : (raw.translationSource ?? 'claude'),
+        translationModel: raw.translationModel,
+      };
+    } catch {
+      /* skip malformed */
+    }
+  }
+  return null;
+}
+
+function writeTranslation(speechId: string, payload: TranslatedSpeech): void {
+  mkdirSync(TRANSLATIONS_DIR_NEW, { recursive: true });
+  writeFileSync(
+    `${TRANSLATIONS_DIR_NEW}/${speechId}.json`,
+    `${JSON.stringify(payload, null, 2)}\n`
+  );
+}
+
+export interface TranslateOptions {
+  /** Override claude model alias. Defaults to env / haiku. */
+  model?: string;
+  /** Skip the tldr LLM call (useful for dry-run smoke tests). */
+  skipTldr?: boolean;
+  /** Re-translate paragraphs even if a cache entry exists. */
+  force?: boolean;
+}
+
+export async function translateSpeeches(
+  fetched: FetchedSpeech[],
+  options: TranslateOptions = {}
+): Promise<TranslateResult> {
+  const model = options.model || process.env.SGAI_TRANSLATION_MODEL || 'haiku';
+  const translated: TranslatedSpeech[] = [];
+  const failures: TranslateResult['failures'] = [];
+
+  for (const f of fetched) {
+    try {
+      const existing = readExistingTranslation(f.speechId);
+      // Hand-curated translation (manual or claude) with both paragraphs +
+      // tldr present → use as-is (refresh-pipeline must not overwrite).
+      if (
+        existing &&
+        existing.translationSource === 'manual' &&
+        existing.paragraphs.length > 0
+      ) {
+        translated.push({
+          ...existing,
+          paragraphsEn: f.paragraphs,
+        });
+        continue;
+      }
+      // If we have full coverage from a prior auto-run, skip — unless forced.
+      if (
+        !options.force &&
+        existing &&
+        existing.paragraphs.length === f.paragraphs.length &&
+        existing.tldr.length > 0
+      ) {
+        translated.push({
+          ...existing,
+          paragraphsEn: f.paragraphs,
+        });
+        continue;
+      }
+
+      const zhParagraphs = await translateBatch(f.paragraphs, {
+        direction: 'en→zh',
+        model,
+        cacheDir: ZH_PARAGRAPH_CACHE,
+        force: options.force,
+      });
+
+      let tldr: string[] = existing?.tldr ?? [];
+      let tldrEn: string[] = existing?.tldrEn ?? [];
+      if (!options.skipTldr && (tldr.length === 0 || tldrEn.length === 0 || options.force)) {
+        const out = await summarizeTldr(f, model);
+        tldr = out.tldr;
+        tldrEn = out.tldrEn;
+      }
+
+      const payload: TranslatedSpeech = {
+        speechId: f.speechId,
+        paragraphs: zhParagraphs,
+        paragraphsEn: f.paragraphs,
+        tldr,
+        tldrEn,
+        translatedAt: new Date().toISOString().slice(0, 10),
+        translationSource: 'claude',
+        translationModel: model,
+      };
+      writeTranslation(f.speechId, payload);
+      translated.push(payload);
+    } catch (error) {
+      failures.push({
+        speechId: f.speechId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return { translated, failures };
+}


### PR DESCRIPTION
## Problem

The NANA speech case ([b460b22](https://github.com/meltflake/sgai/commit/b460b22)) surfaced two pipeline gaps that bit at the same time:

1. **02 regex regression** — `scripts/voices/02_fetch_speeches.py` assumed `title:` came first in `mddiSpeeches[]` entries. After the i18n refactor moved `titleEn:` first, the regex stopped matching anything. Bug only surfaced when someone (Task A) tried to fetch the NANA transcript on 2026-05-15.
2. **Translation was never scripted** — 02 fetched English; 03 read `scripts/voices/data/translations/<id>.json` if humans wrote one, otherwise paragraphs stayed empty. Adding a row to `voices.ts` immediately created a live `/speeches/<id>` route, but the page rendered "此演讲尚未本地存档 / Local archive not yet available" until someone manually hand-translated.

Net result: every weekly MDDI speech needed three sequential manual steps (run 02 → hand-translate → run 03 → review → commit) before the site stopped lying to readers. Task A fixes (1) on the primary branch. This PR fixes (2) by replacing the manual dance with an auto-PR pipeline matching the policies / ecosystem / talent / startups pattern.

## Pipeline shape

Before (3-stage Python + manual translation):

```
01_scan_mddi.py            → scripts/voices/data/mddi_speeches.json
02_fetch_speeches.py       → scripts/voices/data/speeches/<id>.json
[human writes scripts/voices/data/translations/<id>.json — translation, tldr]
03_generate_ts.py          → src/data/speech-transcripts.ts (full re-emit)
[human appends row to src/data/voices.ts mddiSpeeches[]]
[human commits + opens PR]
```

After (4-stage TS auto-PR, no human in the loop):

```
scripts/refresh/voices/scan.ts      → sitemap → AI-speech URLs, deduped
                                      against voices.ts urls AND
                                      speech-transcripts.ts keys
scripts/refresh/voices/fetch.ts     → page <h1> + paragraphs[] per URL
                                      (regex port of 02's BeautifulSoup
                                      strategies; CloudFront-friendly UA)
scripts/refresh/voices/translate.ts → en→zh paragraphs via lib/translate.ts
                                      sha256 cache + zh+en tldr (4-7 bullets)
                                      via lib/llm.ts; preserves hand-curated
                                      translations marked `translationSource: 'manual'`
scripts/refresh/voices/emit.ts      → line-based insert into voices.ts
                                      mddiSpeeches[] (titleEn/title/titleJa,
                                      eventEn/event/eventJa,
                                      speakerTitleEn/speakerTitle/speakerTitleJa,
                                      addedAt: today) AND speech-transcripts.ts
                                      speechTranscripts map (paragraphs zh+en,
                                      tldr zh+en). findUnpairedFields
                                      baseline-vs-after on both files;
                                      rollback only on regression.
scripts/refresh/voices/run.ts       → orchestrator; --dry-run / --limit=N
                                      / --no-commit / --no-push / --force.
                                      autoCommit + pushAndOpenPR via gh.
```

Registry flipped: `voices` is now `type: 'tsx'`, `mode: 'auto-pr'`, weekly schedule kept. `auto_update.py` dropped the `run_voices` python-builtin path and the `'voices'` entry from `scan_only_pids` — the tsx entry self-dispatches through the same `run_tsx_pipeline()` channel as the other 10 auto-PR pipelines.

## Boundary with Task A / B

- **Task A** (regex fix on primary branch, NANA transcript): preserved. `translate.ts` reads `scripts/voices/data/translations/<id>.json` as ground truth and never overwrites entries marked `translationSource: 'manual'`. The legacy dir is the priority; the new pipeline writes to `scripts/refresh/voices/data/translations/<id>.json` so we don't shadow hand-curated files.
- **Task B** (`scripts/evals/transcript-coverage.ts`): untouched. Once it merges, every voices.ts entry without a matching speech-transcripts.ts entry with non-empty paragraphs fails CI — which is exactly what this pipeline ensures going forward.

## Test plan

- [x] `npx tsx scripts/refresh/voices/run.ts --dry-run --limit=1` — end-to-end without writes. Sitemap returned 61 AI-speech URLs total, 2 new (the prior NANA URL + a newly-discovered "PQ on review of PDPA 2012 to address use of inferred/derived data generated by AI" response). Default `--limit=3` cap honoured.
- [x] `npm run check` — astro check (0 errors), eslint (0 errors), check:graph, check:video-transcripts, check:debate-transcripts, check:i18n-completeness, test:lib (57 lib unit tests) all pass.
- [x] `npm run build` — 3098 pages built in 160s.
- [x] `npm run check:dist` — check:i18n (0 zh residue on 1026 EN pages), check:schema (0 issues across 3099 pages).
- [x] `npx tsx scripts/lib/i18n-pair.ts --locales=en,ja src/data/voices.ts src/data/speech-transcripts.ts` — all checks pass.
- [x] `npx eslint scripts/refresh/voices/*.ts` — clean.

## Known limitations

- **Pre-existing prettier drift on `src/pages/tracker/methodology.astro`** — `npm run check:prettier` flags it on this worktree-agent branch. The file was last touched in [5d4d69f](https://github.com/meltflake/sgai/commit/5d4d69f) on a different branch and somehow drifted again. NOT introduced by this PR. Fix is one `npx prettier --write src/pages/tracker/methodology.astro` away in a separate cleanup PR; leaving for owner to handle so this PR stays scoped.
- **No HTML parser dependency** — paragraph extraction is regex-based (port of 02's BeautifulSoup strategies). MDDI's template is stable enough that this works, but if MDDI rebuilds the site we may want to add `cheerio` / `node-html-parser` later.
- **Speaker title trilingual via SPEAKER_MAP** — 5 known speakers (Josephine Teo, Tan Kiat How, Rahayu Mahzam, Janil Puthucheary, Jasmin Lau) have a hand-curated zh/en/ja title triplet. Unknown speakers fall back to `en→zh` + `en→ja` translation of the page-derived English title. New ministers / SMSs may need a manual SPEAKER_MAP append after their first speech.
- **No `--only=<speechId>` re-run flag** — if a single speech translation goes wrong, the operator deletes its cache + JSON files and reruns. Adding a single-id rerun flag is a future enhancement; the existing flags cover the 80% case.
- **`scripts/voices/01_scan_mddi.py` / `02_fetch_speeches.py` / `03_generate_ts.py` kept on disk** — they're still useful for one-off manual operations (full-corpus re-emit, debug fetches). The cron path no longer touches them. Could be deleted in a follow-up once the tsx pipeline has a few weeks under its belt.