### PR TITLE
fix(references): point EU AI Act at EUR-Lex ELI permalink

### DIFF
--- a/src/data/references.ts
+++ b/src/data/references.ts
@@ -246,7 +246,7 @@ export const sections: ReferenceSection[] = [
       {
         text: 'EU AI Act',
         textEn: 'EU AI Act',
-        url: 'https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai',
+        url: 'https://eur-lex.europa.eu/eli/reg/2024/1689/oj',
       },
       {
         text: 'ASEAN Guide on AI Governance and Ethics',


### PR DESCRIPTION
## Summary

- url-health 2026-05-21 ([report](scripts/evals/url-health/reports/report-20260521.md)) flagged \`references.ts:249\` for HTTP 502.
- Tested directly: \`digital-strategy.ec.europa.eu\` returns 502 from CloudFront on default + browser UA — sustained outage / page taken down, not a soft block.
- Swapped to the authoritative EUR-Lex ELI permalink \`https://eur-lex.europa.eu/eli/reg/2024/1689/oj\` (Regulation (EU) 2024/1689 — the AI Act). ELI URIs are designed to not rot.

## Test plan

- [x] \`curl -I https://eur-lex.europa.eu/eli/reg/2024/1689/oj\` → 202 (pass per \`isReachable\` in scripts/lib/url-check.ts:45).
- [ ] After merge: next weekly url-health eval drops references.ts from broken list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)