### PR TITLE
fix(schema): emit Article JSON-LD on policy detail pages

### DIFF
--- a/src/pages/[lang]/policies/[id].astro
+++ b/src/pages/[lang]/policies/[id].astro
@@ -36,7 +36,20 @@ const metadata = {
   description: summary,
 };
 
+const datePadded =
+  policy.date.length === 4 ? `${policy.date}-01-01` : policy.date.length === 7 ? `${policy.date}-01` : policy.date;
+const datePublished = `${datePadded}T00:00:00+08:00`;
+
 const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: title,
+  datePublished,
+  description: summary,
+  ...(policy.ministry ? { author: { '@type': 'Organization', name: policy.ministry } } : {}),
+};
+
+const govServiceSchema = {
   '@context': 'https://schema.org',
   '@type': 'GovernmentService',
   name: policy.titleEn || policy.title,
@@ -51,5 +64,6 @@ const breadcrumbs = [{ label: t(lang, 'navPolicies'), href: localizedHref('/poli
 
 <Layout metadata={metadata} breadcrumbs={breadcrumbs} lang={lang}>
   <JsonLd schema={articleSchema} />
+  <JsonLd schema={govServiceSchema} />
   <PolicyProfile policy={policy} lang={lang} />
 </Layout>

--- a/src/pages/policies/[id].astro
+++ b/src/pages/policies/[id].astro
@@ -35,7 +35,20 @@ const metadata = {
   description: summary,
 };
 
+const datePadded =
+  policy.date.length === 4 ? `${policy.date}-01-01` : policy.date.length === 7 ? `${policy.date}-01` : policy.date;
+const datePublished = `${datePadded}T00:00:00+08:00`;
+
 const articleSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Article',
+  headline: policy.titleEn || policy.title,
+  datePublished,
+  description: summary,
+  ...(policy.ministry ? { author: { '@type': 'Organization', name: policy.ministry } } : {}),
+};
+
+const govServiceSchema = {
   '@context': 'https://schema.org',
   '@type': 'GovernmentService',
   name: policy.titleEn || policy.title,
@@ -49,5 +62,6 @@ const breadcrumbs = [{ label: t(lang, 'navPolicies'), href: localizedHref('/poli
 
 <Layout metadata={metadata} breadcrumbs={breadcrumbs} lang={lang}>
   <JsonLd schema={articleSchema} />
+  <JsonLd schema={govServiceSchema} />
   <PolicyProfile policy={policy} lang={lang} />
 </Layout>


### PR DESCRIPTION
## Summary

- schema-richresults expects \`Article + BreadcrumbList\` on \`policy-first\` but the templates only emitted \`GovernmentService\` → \`Article._presence\` ERROR on \`ai-in-healthcare-guidelines-aihgle\`.
- Both EN (\`src/pages/policies/[id].astro\`) and \`[lang]\` (\`src/pages/[lang]/policies/[id].astro\`) templates now emit Article + GovernmentService.
- \`datePublished\` normalised to ISO 8601 (\`YYYY\` / \`YYYY-MM\` get padded to \`YYYY-01-01\` / \`YYYY-MM-01\`) so the regex in \`scripts/evals/schema-richresults/check.ts:38\` accepts all policy dates.

## Test plan

- [x] \`npm run check\` (astro + eslint + prettier + tests) — 93/93 pass.
- [x] \`npm run build\` — full SSG completes.
- [x] \`npx tsx scripts/evals/schema-richresults/check.ts\` — \`policy-first\` is now \`PASS\` with 2 tolerated warns (\`dateModified\` / \`image\` recommended), down from 1 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)