### PR TITLE
Fix blog category slug leaking as literal text

### DIFF
--- a/src/components/blog/ListItem.astro
+++ b/src/components/blog/ListItem.astro
@@ -21,6 +21,7 @@ const image = (await findImage(post.image)) as ImageMetadata | undefined;
 const lang = getLangFromPath(new URL(Astro.url).pathname);
 
 const link = APP_BLOG?.post?.isEnabled ? localizedHref(getPermalink(post.permalink, 'post'), lang) : '';
+const categoryHref = post.category?.slug ? getPermalink(post.category.slug, 'category') : '';
 ---
 
 <article
@@ -86,8 +87,8 @@ const link = APP_BLOG?.post?.isEnabled ? localizedHref(getPermalink(post.permali
               <>
                 {' '}
                 ·{' '}
-                {post.category.slug ? (
-                  <a class="hover:underline" href={getPermalink(post.category.slug, 'category')}>
+                {categoryHref ? (
+                  <a class="hover:underline" href={categoryHref}>
                     {post.category.title}
                   </a>
                 ) : (

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -18,6 +18,7 @@ export interface Props {
 
 const { post, url } = Astro.props;
 const lang = getLangFromPath(new URL(Astro.url).pathname);
+const categoryHref = post.category?.slug ? getPermalink(post.category.slug, 'category') : '';
 ---
 
 <section class="py-8 sm:py-16 lg:py-20 mx-auto">
@@ -59,8 +60,8 @@ const lang = getLangFromPath(new URL(Astro.url).pathname);
               <>
                 {' '}
                 ·{' '}
-                {post.category.slug ? (
-                  <a class="hover:underline inline-block" href={getPermalink(post.category.slug, 'category')}>
+                {categoryHref ? (
+                  <a class="hover:underline inline-block" href={categoryHref}>
                     {post.category.title}
                   </a>
                 ) : (


### PR DESCRIPTION
## Summary

- Fix `post.category.slug ? ( 观察 ) : (观察)` rendering as literal text in blog listing and single post pages
- Move category permalink computation from inline Astro template ternary to a frontmatter variable (`categoryHref`), avoiding a nested expression pattern that the Astro compiler mishandles in some paths

## Files changed

- `src/components/blog/ListItem.astro` — blog listing card metadata
- `src/components/blog/SinglePost.astro` — individual post page metadata

## Test plan

- [x] `npm run check` passes (astro, eslint, prettier, graph)
- [x] `npm run build` succeeds
- [x] Built HTML at `/blog/index.html` renders category as `<a>` link, no literal expression text

https://claude.ai/code/session_0154nbWfBF2LkQr3mxFcu2RH

---
_Generated by [Claude Code](https://claude.ai/code/session_0154nbWfBF2LkQr3mxFcu2RH)_