### PR TITLE
fix(refresh): emit *Ko fields in policies + ecosystem + videos emit formatters

### DIFF
--- a/scripts/refresh/ecosystem/emit.ts
+++ b/scripts/refresh/ecosystem/emit.ts
@@ -33,12 +33,17 @@ function formatEntity(e: EnrichedEntity): string {
   lines.push(`        name: '${escapeQuote(s.title)}',`);
   lines.push(`        nameEn: '${escapeQuote(s.titleEn)}',`);
   if (s.titleJa) lines.push(`        nameJa: '${escapeQuote(s.titleJa)}',`);
+  if (s.titleKo) lines.push(`        nameKo: '${escapeQuote(s.titleKo)}',`);
   lines.push(`        description: '${escapeQuote(s.description)}',`);
   lines.push(`        descriptionEn:`);
   lines.push(`          '${escapeQuote(s.descriptionEn)}',`);
   if (s.descriptionJa) {
     lines.push(`        descriptionJa:`);
     lines.push(`          '${escapeQuote(s.descriptionJa)}',`);
+  }
+  if (s.descriptionKo) {
+    lines.push(`        descriptionKo:`);
+    lines.push(`          '${escapeQuote(s.descriptionKo)}',`);
   }
   lines.push(`        url: '${e.candidate.sourceUrl}',`);
   lines.push(`        entityType: '${e.candidate.defaultEntityType}',`);

--- a/scripts/refresh/policies/emit.ts
+++ b/scripts/refresh/policies/emit.ts
@@ -50,6 +50,7 @@ function formatPolicyRecord(p: EnrichedPolicy, defaultMinistry?: string): string
   lines.push(`        title: '${escapeQuote(s.title)}',`);
   lines.push(`        titleEn: '${escapeQuote(s.titleEn)}',`);
   if (s.titleJa) lines.push(`        titleJa: '${escapeQuote(s.titleJa)}',`);
+  if (s.titleKo) lines.push(`        titleKo: '${escapeQuote(s.titleKo)}',`);
   lines.push(`        date: '${date}',`);
   lines.push(`        source: '${escapeQuote(p.candidate.defaultSource)}',`);
   lines.push(`        sourceOrgUrl: '${p.candidate.defaultSourceOrgUrl}',`);
@@ -64,6 +65,10 @@ function formatPolicyRecord(p: EnrichedPolicy, defaultMinistry?: string): string
   if (s.descriptionJa) {
     lines.push(`        summaryJa: '${escapeQuote(s.descriptionJa)}',`);
     lines.push('        contentJa: `' + escapeBacktick(s.descriptionJa) + '`,');
+  }
+  if (s.descriptionKo) {
+    lines.push(`        summaryKo: '${escapeQuote(s.descriptionKo)}',`);
+    lines.push('        contentKo: `' + escapeBacktick(s.descriptionKo) + '`,');
   }
   lines.push(`        sourceEn: '${escapeQuote(p.candidate.defaultSourceEn)}',`);
   if (defaultMinistry) {

--- a/scripts/refresh/videos/emit.ts
+++ b/scripts/refresh/videos/emit.ts
@@ -434,12 +434,14 @@ function buildEntrySnippet(e: ApprovedEntry): string {
     `    titleEn: '${escapeTsString(f.titleEn)}',`,
   ];
   if (f.titleJa) lines.push(`    titleJa: '${escapeTsString(f.titleJa)}',`);
+  if (f.titleKo) lines.push(`    titleKo: '${escapeTsString(f.titleKo)}',`);
   lines.push(
     `    speaker: '${escapeTsString(f.speaker)}',`,
     `    speakerTitle: '${escapeTsString(f.speakerTitle)}',`,
     `    speakerTitleEn: '${escapeTsString(f.speakerTitleEn)}',`,
   );
   if (f.speakerTitleJa) lines.push(`    speakerTitleJa: '${escapeTsString(f.speakerTitleJa)}',`);
+  if (f.speakerTitleKo) lines.push(`    speakerTitleKo: '${escapeTsString(f.speakerTitleKo)}',`);
   lines.push(
     `    speakerType: '${f.speakerType}',`,
     `    date: '${e.date}',`,
@@ -448,11 +450,13 @@ function buildEntrySnippet(e: ApprovedEntry): string {
     `    summaryEn: '${escapeTsString(f.summaryEn)}',`,
   );
   if (f.summaryJa) lines.push(`    summaryJa: '${escapeTsString(f.summaryJa)}',`);
+  if (f.summaryKo) lines.push(`    summaryKo: '${escapeTsString(f.summaryKo)}',`);
   lines.push(
     `    topic: '${escapeTsString(f.topic)}',`,
     `    topicEn: '${escapeTsString(f.topicEn)}',`,
   );
   if (f.topicJa) lines.push(`    topicJa: '${escapeTsString(f.topicJa)}',`);
+  if (f.topicKo) lines.push(`    topicKo: '${escapeTsString(f.topicKo)}',`);
   lines.push(
     `    youtubeUrl: '${e.youtubeUrl}',`,
     `    channel: '${escapeTsString(e.channel)}',`,


### PR DESCRIPTION
## Problem

Three refresh pipelines compute `zh→ko` translations and their record interfaces declare `*Ko` fields, but the **bespoke emit formatters** only wrote `*En` + `*Ja` siblings — they silently dropped every `*Ko` value.

The emit-time i18n gate (`findUnpairedFields`) defaults to `locales: ['en','ja','ko']`, and all existing records in these files already carry `*Ko`. So every newly-scanned record came out missing its Ko sibling → `i18n pairing regressed` → automatic rollback. **policies, ecosystem, and videos refresh could not emit any new record.**

## Fix — mirror the existing `*Ja` handling

- `policies/emit.ts` `formatPolicyRecord`: write `titleKo` / `summaryKo` / `contentKo`.
- `ecosystem/emit.ts` `formatEntity`: write `nameKo` / `descriptionKo`.
- `videos/emit.ts` record formatter: write `titleKo` / `summaryKo` / `topicKo` / `speakerTitleKo`.

Verified by running all three against live candidates — emit now writes Ko fields with no rollback. The videos pipeline produced a fully en/ja/ko/zh-aligned `v066` (shipped separately in #62). Scripts-only change; no effect on `dist/`.

## Known follow-up (NOT in this PR)

The auto-discovery pipelines also have a separate **completeness-gate** gap (the `--mode=both` check on `ecosystem.ts`):
- `ecosystem` entities lack required `whatItIs` / `aiRelevance` / `singaporeRelevance` (+ locale siblings) and `sources[].label` siblings — the enrich doesn't generate them.
- `policies` records emit only `sourceEn` (missing `sourceJa`/`sourceKo`) for the required `source` field.

So policies/ecosystem auto-discovered data still can't be committed until the enrich produces those fields (or pending stubs are exempted with `i18n-allow-unpaired`). This PR only fixes the Ko-alignment drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)