### PR TITLE
fix(refresh): repair pipeline gates — addedAt exemption, completeness, prettier, scanner

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "check:zh-tw-misconversion": "tsx scripts/evals/zh-tw-misconversion/check.ts",
     "check:dist": "npm run check:i18n && npm run check:schema && npm run check:zh-tw-misconversion",
     "check:skill-urls": "tsx scripts/skill-url-check.ts",
-    "test:lib": "tsx --test scripts/lib/__tests__/*.test.ts scripts/data-relations/__tests__/*.test.ts",
+    "test:lib": "tsx --test scripts/lib/__tests__/*.test.ts scripts/data-relations/__tests__/*.test.ts scripts/evals/addedAt-coverage/__tests__/*.test.ts scripts/refresh/policies/__tests__/*.test.ts",
     "i18n-pair": "tsx scripts/lib/i18n-pair.ts",
     "eval": "tsx scripts/evals/run-all.ts",
     "eval:url": "tsx scripts/evals/url-health/check.ts",

--- a/scripts/evals/addedAt-coverage/__tests__/check.test.ts
+++ b/scripts/evals/addedAt-coverage/__tests__/check.test.ts
@@ -1,0 +1,232 @@
+// scripts/evals/addedAt-coverage/__tests__/check.test.ts
+// ────────────────────────────────────────────────────────────────────────
+// Behavioural contract for the addedAt-coverage eval's diff analyzer.
+//
+// CLAUDE.md rule #7: pending-review records do NOT carry `addedAt` until a
+// human promotes them. They take several shapes:
+//   - `autoDiscovered[]` const arrays   (startups / tracker / talent / benchmarking)
+//   - "Auto-discovered (pending review)" group / section (levers / legal-ai)
+//   - `_pendingReview: true` field        (ecosystem)
+//   - `// _pendingReview` comment         (policies, low confidence)
+// All four must PASS the eval without addedAt. A real record without addedAt
+// must still FAIL.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { analyzeDiff, evaluateFileDiff, exemptLineRanges } from '../check.ts';
+
+const FILE = 'src/data/test.ts';
+
+/** Emit a minimal `git diff --unified=0` patch with one hunk. */
+function makeDiff(newStart: number, addedLines: string[]): string {
+  const head = [
+    `diff --git a/${FILE} b/${FILE}`,
+    `index 1111111..2222222 100644`,
+    `--- a/${FILE}`,
+    `+++ b/${FILE}`,
+    `@@ -${newStart},0 +${newStart},${addedLines.length} @@`,
+  ];
+  return [...head, ...addedLines.map((l) => `+${l}`)].join('\n') + '\n';
+}
+
+/**
+ * Given the full working-tree file as lines and the 1-based inclusive range
+ * of lines that are "new" in the diff, return a consistent { source, diff }
+ * pair (the diff's added lines are guaranteed to equal the source lines at
+ * those positions — so `@@` line numbers line up with the source).
+ */
+function buildCase(lines: string[], addedStart: number, addedEnd: number) {
+  const added = lines.slice(addedStart - 1, addedEnd);
+  return { source: lines.join('\n') + '\n', diff: makeDiff(addedStart, added) };
+}
+
+// ── 1. autoDiscovered[] anonymous entry (startups style) — PASS ──────────
+test('autoDiscovered[] entry without addedAt PASSES (anonymous, no id)', () => {
+  const lines = [
+    'export const startups = [',
+    "  { id: 'real-existing', addedAt: '2026-01-01' },",
+    '];',
+    '',
+    'export interface AutoDiscoveredEntry {',
+    '  title: string;',
+    '}',
+    'export const autoDiscovered: AutoDiscoveredEntry[] = [',
+    '  {',
+    "    title: '新创业公司',",
+    "    titleEn: 'New Startup',",
+    "    description: '描述',",
+    "    descriptionEn: 'Desc',",
+    "    category: 'startup',",
+    "    confidence: 'low',",
+    "    sourceUrl: 'https://example.com',",
+    "    discoveredAt: '2026-06-19',",
+    '  },',
+    '];',
+  ];
+  const { source, diff } = buildCase(lines, 9, 18); // the entry `{ ... },`
+  const finding = evaluateFileDiff(FILE, diff, source);
+  assert.equal(finding.status, 'PASS', `expected PASS, got ${JSON.stringify(finding)}`);
+  assert.equal(finding.newRecords, 0);
+});
+
+// ── 2. levers "Auto-discovered (pending review)" item (has id) — PASS ────
+test('Auto-discovered group item with id but no addedAt PASSES (levers style)', () => {
+  const lines = [
+    'export const levers = [',
+    '  {',
+    '    number: 1,',
+    '    groups: [',
+    '      {',
+    "        title: 'Auto-discovered (pending review)',",
+    "        titleEn: 'Auto-discovered (pending review)',",
+    '        items: [',
+    '          {',
+    "            id: 'auto-item',",
+    "            name: '自动项',",
+    "            nameEn: 'Auto Item',",
+    '          },',
+    '        ],',
+    '      },',
+    '    ],',
+    '  },',
+    '];',
+  ];
+  const { source, diff } = buildCase(lines, 9, 13); // the item `{ ... },`
+  const finding = evaluateFileDiff(FILE, diff, source);
+  assert.equal(finding.status, 'PASS', `expected PASS, got ${JSON.stringify(finding)}`);
+  assert.deepEqual(finding.newRecordIds, []);
+});
+
+// ── 3. ecosystem `_pendingReview: true` record (has id) — PASS ───────────
+test('ecosystem _pendingReview:true record with id but no addedAt PASSES', () => {
+  const lines = [
+    'export const ecosystemCategories = [',
+    '  {',
+    "    name: 'Cat',",
+    '    entities: [',
+    '      {',
+    "        id: 'eco-1',",
+    "        name: '生态实体',",
+    "        nameEn: 'Eco Entity',",
+    '        _pendingReview: true,',
+    '      },',
+    '    ],',
+    '  },',
+    '];',
+  ];
+  const { source, diff } = buildCase(lines, 5, 10);
+  const finding = evaluateFileDiff(FILE, diff, source);
+  assert.equal(finding.status, 'PASS', `expected PASS, got ${JSON.stringify(finding)}`);
+  assert.deepEqual(finding.newRecordIds, []);
+});
+
+// ── 4. policies `// _pendingReview` comment record (has id) — PASS ───────
+test('policies record with // _pendingReview comment but no addedAt PASSES', () => {
+  const lines = [
+    'export const policies = [',
+    '  {',
+    "    name: 'Strat',",
+    '    policies: [',
+    '      {',
+    "        id: 'pol-low',",
+    "        title: '低置信政策',",
+    "        titleEn: 'Low conf',",
+    '        // _pendingReview: low confidence — uncertain',
+    '      },',
+    '    ],',
+    '  },',
+    '];',
+  ];
+  const { source, diff } = buildCase(lines, 5, 10);
+  const finding = evaluateFileDiff(FILE, diff, source);
+  assert.equal(finding.status, 'PASS', `expected PASS, got ${JSON.stringify(finding)}`);
+});
+
+// ── 5. real record without addedAt — must still FAIL ─────────────────────
+test('real record (not pending-review) without addedAt FAILS', () => {
+  const lines = [
+    'export const videos = [',
+    '  {',
+    "    id: 'v999',",
+    "    title: '真实视频',",
+    "    titleEn: 'Real Video',",
+    '  },',
+    '];',
+  ];
+  const { source, diff } = buildCase(lines, 2, 6);
+  const finding = evaluateFileDiff(FILE, diff, source);
+  assert.equal(finding.status, 'FAIL', `expected FAIL, got ${JSON.stringify(finding)}`);
+  assert.deepEqual(finding.newRecordIds, ['v999']);
+  assert.equal(finding.missing, 1);
+});
+
+// ── 6. real record WITH addedAt — PASS (sanity) ──────────────────────────
+test('real record with addedAt PASSES', () => {
+  const lines = [
+    'export const videos = [',
+    '  {',
+    "    id: 'v999',",
+    "    title: '真实视频',",
+    "    titleEn: 'Real Video',",
+    "    addedAt: '2026-06-19',",
+    '  },',
+    '];',
+  ];
+  const { source, diff } = buildCase(lines, 2, 7);
+  const finding = evaluateFileDiff(FILE, diff, source);
+  assert.equal(finding.status, 'PASS', `expected PASS, got ${JSON.stringify(finding)}`);
+});
+
+// ── 7. multiple real records, one missing addedAt — FAILS ────────────────
+test('two real records where one lacks addedAt FAILS (missing=1)', () => {
+  const lines = [
+    'export const videos = [',
+    '  {',
+    "    id: 'v100',",
+    "    title: '甲',",
+    "    titleEn: 'A',",
+    "    addedAt: '2026-06-19',",
+    '  },',
+    '  {',
+    "    id: 'v101',",
+    "    title: '乙',",
+    "    titleEn: 'B',",
+    '  },',
+    '];',
+  ];
+  const { source, diff } = buildCase(lines, 2, 12);
+  const finding = evaluateFileDiff(FILE, diff, source);
+  assert.equal(finding.status, 'FAIL', `expected FAIL, got ${JSON.stringify(finding)}`);
+  assert.equal(finding.newRecords, 2);
+  assert.equal(finding.newAddedAt, 1);
+  assert.equal(finding.missing, 1);
+});
+
+// ── 8. exemptLineRanges directly ─────────────────────────────────────────
+test('exemptLineRanges finds autoDiscovered array span', () => {
+  const source = [
+    'export const xs = [',
+    "  { id: 'a' },",
+    '];',
+    'export const autoDiscovered: AutoDiscoveredEntry[] = [',
+    '  {',
+    "    title: 'x',",
+    '  },',
+    '];',
+  ].join('\n');
+  const ranges = exemptLineRanges(source);
+  // The autoDiscovered array spans source lines 4..8 (1-based).
+  assert.ok(
+    ranges.some(([a, b]) => a === 4 && b === 8),
+    `expected a [4,8] range, got ${JSON.stringify(ranges)}`
+  );
+  // The normal `xs` array (lines 1..3) must NOT be exempt.
+  assert.ok(!ranges.some(([a, b]) => a <= 2 && 2 <= b), 'line 2 must not be exempt');
+});
+
+// ── 9. analyzeDiff: empty diff is a no-op ────────────────────────────────
+test('analyzeDiff returns zero counts for empty diff', () => {
+  const stats = analyzeDiff('', 'export const xs = [];\n');
+  assert.deepEqual(stats, { newRecordIds: [], newAddedAtCount: 0, anonymousRecordOpens: 0 });
+});

--- a/scripts/evals/addedAt-coverage/check.ts
+++ b/scripts/evals/addedAt-coverage/check.ts
@@ -88,7 +88,7 @@ function git(args: string[]): string {
   }
 }
 
-interface DiffStats {
+export interface DiffStats {
   newRecordIds: string[]; // ids extracted from `+ id: 'xxx'` lines
   newAddedAtCount: number;
   // Heuristic: records added without an `id:` line (e.g. LegalItem,
@@ -97,19 +97,97 @@ interface DiffStats {
   anonymousRecordOpens: number;
 }
 
-function diffFile(file: string, base: string): DiffStats {
-  let raw: string;
-  try {
-    // Compare base → working tree (NOT base...HEAD). This catches both
-    // committed-since-base changes AND uncommitted edits in the worktree,
-    // which matters for local pre-commit runs and for catching the case
-    // where someone forgot to stage `addedAt` after staging the record.
-    raw = git(['diff', base, '--unified=0', '--', file]);
-  } catch {
-    // base ref may not exist locally (shallow clone) — bail out empty
-    raw = '';
+// ── Pending-review exemption (CLAUDE.md rule #7) ─────────────────────────
+// Pending-review records do NOT carry `addedAt` until a human promotes them,
+// so the eval must not demand it. They appear in three shapes:
+//   1. inside an `autoDiscovered` const array (startups / tracker / talent / benchmarking)
+//   2. inside an object with a `_pendingReview` field/comment
+//      (ecosystem `_pendingReview: true`; policies `// _pendingReview ...`)
+//   3. inside an "Auto-discovered (pending review)" group / section (levers / legal-ai)
+// exemptLineRanges scans the working-tree source and returns the 1-based line
+// ranges occupied by such records; analyzeDiff maps each diff `+` line to a
+// source line and drops records whose line falls inside a range.
+
+/** Blank out string literals and `//` comments so brace/bracket counting
+ *  isn't fooled by punctuation inside values. Strings are stripped first so a
+ *  `//` inside a URL literal isn't mistaken for the start of a comment. */
+function stripLiterals(line: string): string {
+  let s = line
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""')
+    .replace(/`(?:\\.|[^`\\])*`/g, '``');
+  const c = s.indexOf('//');
+  if (c >= 0) s = s.slice(0, c);
+  return s;
+}
+
+/** Match every balanced open/close pair across the file, returning
+ *  [openLineIdx, closeLineIdx] (0-based) for each matched pair. */
+function matchPairs(lines: string[], open: string, close: string): Array<[number, number]> {
+  const stack: number[] = [];
+  const pairs: Array<[number, number]> = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    for (const ch of stripLiterals(lines[i])) {
+      if (ch === open) stack.push(i);
+      else if (ch === close) {
+        const o = stack.pop();
+        if (o !== undefined) pairs.push([o, i]);
+      }
+    }
   }
-  if (!raw.trim()) return { newRecordIds: [], newAddedAtCount: 0, anonymousRecordOpens: 0 };
+  return pairs;
+}
+
+/** Smallest pair (fewest lines) that contains `idx`, or null. */
+function innermostContaining(pairs: Array<[number, number]>, idx: number): [number, number] | null {
+  let best: [number, number] | null = null;
+  for (const [o, c] of pairs) {
+    if (o <= idx && idx <= c && (!best || c - o < best[1] - best[0])) best = [o, c];
+  }
+  return best;
+}
+
+export function exemptLineRanges(source: string): Array<[number, number]> {
+  const lines = source.split('\n');
+  const ranges: Array<[number, number]> = [];
+  const bracketPairs = matchPairs(lines, '[', ']');
+  const bracePairs = matchPairs(lines, '{', '}');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    // (1) `export const autoDiscovered ... = [ ... ]` — the widest `[...]`
+    // opening on the declaration line (skips the `AutoDiscoveredEntry[]` type).
+    if (/export const autoDiscovered\b/.test(lines[i])) {
+      let widest: [number, number] | null = null;
+      for (const [o, c] of bracketPairs) {
+        if (o === i && (!widest || c - o > widest[1] - widest[0])) widest = [o, c];
+      }
+      if (widest) ranges.push([widest[0] + 1, widest[1] + 1]);
+    }
+    // (2)/(3) `_pendingReview` field or comment, or an "Auto-discovered
+    // (pending review)" marker → exempt the whole enclosing object.
+    if (/_pendingReview/.test(lines[i]) || /Auto-discovered \(pending review\)/.test(lines[i])) {
+      const r = innermostContaining(bracePairs, i);
+      if (r) ranges.push([r[0] + 1, r[1] + 1]);
+    }
+  }
+  return ranges;
+}
+
+/**
+ * Parse a `git diff <base> --unified=0` patch for one data file and count
+ * new records vs new `addedAt` fields.
+ *
+ * `currentSource` is the working-tree contents of the same file. Because the
+ * diff is base → working tree, every `+` line maps to a line number in
+ * `currentSource`; we use that mapping (via the `@@` hunk headers) to drop
+ * records that live inside a pending-review region — see exemptLineRanges.
+ * Pure (no git / fs) so it is unit-testable.
+ */
+export function analyzeDiff(diffText: string, currentSource: string): DiffStats {
+  if (!diffText.trim()) return { newRecordIds: [], newAddedAtCount: 0, anonymousRecordOpens: 0 };
+
+  const exempt = exemptLineRanges(currentSource);
+  const isExempt = (n: number) => exempt.some(([a, b]) => n >= a && n <= b);
 
   const newIdRe = /^\+\s*id:\s*['"]([^'"]+)['"]/;
   const newAddedAtRe = /^\+\s*addedAt:\s*['"][^'"]+['"]/;
@@ -122,42 +200,97 @@ function diffFile(file: string, base: string): DiffStats {
   // carry an `id:` field and are caught by newIdRe directly, regardless of
   // indent.
   const newRecordOpenRe = /^\+\s{2,4}\{\s*$/;
+  // Hunk header carries the new-file start line — `@@ -a,b +c,d @@`. With
+  // --unified=0 there are no context lines, so each subsequent `+` line is a
+  // consecutive new-file line starting at c.
+  const hunkRe = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
 
+  let newLineNo = 0; // working-tree line number of the current `+` line
   let inAddBlock = false;
   let blockHasId = false;
+  let blockOpenLineNo = 0;
   let anonymousOpens = 0;
   const newRecordIds: string[] = [];
   let newAddedAtCount = 0;
 
-  for (const line of raw.split('\n')) {
+  for (const line of diffText.split('\n')) {
+    const hunk = line.match(hunkRe);
+    if (hunk) {
+      newLineNo = Number(hunk[1]);
+      continue;
+    }
+    // Diff/file headers carry no record content; deletions ('-') don't
+    // advance the new-file line counter.
+    if (
+      line.startsWith('+++') ||
+      line.startsWith('---') ||
+      line.startsWith('diff ') ||
+      line.startsWith('index ') ||
+      line.startsWith('@@')
+    ) {
+      continue;
+    }
+    if (!line.startsWith('+')) continue;
+
+    const lineNo = newLineNo;
+    newLineNo += 1;
+
     const idMatch = line.match(newIdRe);
     if (idMatch) {
-      newRecordIds.push(idMatch[1]);
       blockHasId = true;
+      if (!isExempt(lineNo)) newRecordIds.push(idMatch[1]);
       continue;
     }
     if (newAddedAtRe.test(line)) {
-      newAddedAtCount += 1;
+      // Symmetry with the record side: an exempt (pending-review) region
+      // contributes neither records nor addedAts, so it can never mask a
+      // real missing addedAt elsewhere in the file.
+      if (!isExempt(lineNo)) newAddedAtCount += 1;
       continue;
     }
     if (newRecordOpenRe.test(line)) {
-      if (inAddBlock && !blockHasId) anonymousOpens += 1;
+      if (inAddBlock && !blockHasId && !isExempt(blockOpenLineNo)) anonymousOpens += 1;
       inAddBlock = true;
       blockHasId = false;
+      blockOpenLineNo = lineNo;
       continue;
     }
-    if (line.startsWith('+') && line.includes('},')) {
-      if (inAddBlock && !blockHasId) anonymousOpens += 1;
+    if (line.includes('},')) {
+      if (inAddBlock && !blockHasId && !isExempt(blockOpenLineNo)) anonymousOpens += 1;
       inAddBlock = false;
       blockHasId = false;
     }
   }
-  if (inAddBlock && !blockHasId) anonymousOpens += 1;
+  if (inAddBlock && !blockHasId && !isExempt(blockOpenLineNo)) anonymousOpens += 1;
 
   return { newRecordIds, newAddedAtCount, anonymousRecordOpens: anonymousOpens };
 }
 
-interface FileFinding {
+function readDiffAndSource(file: string, base: string): { diffText: string; currentSource: string } {
+  let diffText = '';
+  try {
+    // Compare base → working tree (NOT base...HEAD). This catches both
+    // committed-since-base changes AND uncommitted edits in the worktree,
+    // which matters for local pre-commit runs and for catching the case
+    // where someone forgot to stage `addedAt` after staging the record.
+    diffText = git(['diff', base, '--unified=0', '--', file]);
+  } catch {
+    // base ref may not exist locally (shallow clone) — bail out empty
+    diffText = '';
+  }
+  let currentSource = '';
+  const abs = join(REPO_ROOT, file);
+  if (existsSync(abs)) {
+    try {
+      currentSource = readFileSync(abs, 'utf8');
+    } catch {
+      currentSource = '';
+    }
+  }
+  return { diffText, currentSource };
+}
+
+export interface FileFinding {
   file: string;
   newRecords: number; // ids + anonymous record opens
   newAddedAt: number;
@@ -166,21 +299,28 @@ interface FileFinding {
   status: 'PASS' | 'FAIL';
 }
 
+/** Build a per-file finding from a diff + working-tree source. Pure. */
+export function evaluateFileDiff(file: string, diffText: string, currentSource: string): FileFinding {
+  const d = analyzeDiff(diffText, currentSource);
+  const newRecords = d.newRecordIds.length + d.anonymousRecordOpens;
+  const missing = Math.max(0, newRecords - d.newAddedAtCount);
+  return {
+    file,
+    newRecords,
+    newAddedAt: d.newAddedAtCount,
+    missing,
+    newRecordIds: d.newRecordIds,
+    status: missing > 0 ? 'FAIL' : 'PASS',
+  };
+}
+
 function scanDiffMode(opts: CliOptions): FileFinding[] {
   const out: FileFinding[] = [];
   for (const file of DATA_FILES) {
-    const d = diffFile(file, opts.base);
-    const newRecords = d.newRecordIds.length + d.anonymousRecordOpens;
-    if (newRecords === 0) continue;
-    const missing = Math.max(0, newRecords - d.newAddedAtCount);
-    out.push({
-      file,
-      newRecords,
-      newAddedAt: d.newAddedAtCount,
-      missing,
-      newRecordIds: d.newRecordIds,
-      status: missing > 0 ? 'FAIL' : 'PASS',
-    });
+    const { diffText, currentSource } = readDiffAndSource(file, opts.base);
+    const finding = evaluateFileDiff(file, diffText, currentSource);
+    if (finding.newRecords === 0) continue;
+    out.push(finding);
   }
   return out;
 }
@@ -311,4 +451,8 @@ function main() {
   process.exit(fail > 0 ? 1 : 0);
 }
 
-main();
+// Run as CLI only — importing this module (e.g. from a unit test) must not
+// fire git / writeReport / process.exit.
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('addedAt-coverage/check.ts')) {
+  main();
+}

--- a/scripts/lib/auto-discovered-emit.ts
+++ b/scripts/lib/auto-discovered-emit.ts
@@ -31,6 +31,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 import { findUnpairedFields } from './i18n-pair.ts';
+import { formatWithPrettier } from './prettier-format.ts';
 
 export interface AutoDiscoveredEntry {
   title: string;
@@ -138,6 +139,9 @@ export function appendAutoDiscovered(
       `i18n pairing regressed in auto-discovered emit: ${baselineCount} → ${issuesAfter.length} unpaired. Rolled back.`
     );
   }
+
+  // Prettier-format the spliced-in literals so the PR passes check:prettier.
+  formatWithPrettier(filePath);
 
   return { added: entries.length, created };
 }

--- a/scripts/lib/prettier-format.ts
+++ b/scripts/lib/prettier-format.ts
@@ -1,0 +1,37 @@
+// scripts/lib/prettier-format.ts
+// ────────────────────────────────────────────────────────────────────────
+// Best-effort `prettier --write` on a single file, mirroring the call in
+// scripts/refresh/videos/emit.ts.
+//
+// Refresh pipelines splice hand-formatted TS literals into data files. Those
+// insertions are not prettier-clean (indent / quote / wrap conventions
+// differ), so without this step the resulting PR fails `npm run check:prettier`
+// (`prettier --check .`) — which is what got hand-fixed on #60 / #61.
+//
+// Any pipeline that writes a data file must call this before committing.
+
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * Run `prettier --write <filePath>`. Never throws: a formatting failure must
+ * not abort an otherwise-successful emit. On failure the file is still valid
+ * TS — the worst case is the existing pre-commit prettier gate flags it,
+ * exactly as before this helper existed. Returns true on success.
+ */
+export function formatWithPrettier(filePath: string): boolean {
+  const r = spawnSync('npx', ['prettier', '--write', filePath], {
+    encoding: 'utf8',
+    cwd: ROOT,
+  });
+  if (r.status !== 0) {
+    process.stderr.write(
+      `  ⚠ prettier --write ${filePath} exited ${r.status}: ${(r.stderr || '').slice(0, 200)}\n`
+    );
+    return false;
+  }
+  return true;
+}

--- a/scripts/refresh/ecosystem/emit.ts
+++ b/scripts/refresh/ecosystem/emit.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { findUnpairedFields } from '../../lib/i18n-pair.ts';
+import { formatWithPrettier } from '../../lib/prettier-format.ts';
 import type { EnrichedEntity } from './enrich.ts';
 
 export interface EcosystemEmitResult {
@@ -24,10 +25,15 @@ function escapeQuote(s: string): string {
   return s.replace(/'/g, "\\'");
 }
 
-function formatEntity(e: EnrichedEntity): string {
+export function formatEntity(e: EnrichedEntity): string {
   const s = e.summary;
   const today = new Date().toISOString().slice(0, 10);
   const lines: string[] = [];
+  // Auto-discovered entities are _pendingReview stubs. Their required
+  // analytical fields (whatItIs / aiRelevance / singaporeRelevance) and
+  // sources[].label siblings are filled by a human on promotion, so exempt
+  // the entity (and its nested source below) from the i18n gate (rule #5).
+  lines.push('      // i18n-allow-unpaired — auto-discovered stub; complete required fields on promotion');
   lines.push('      {');
   lines.push(`        id: '${e.id}',`);
   lines.push(`        name: '${escapeQuote(s.title)}',`);
@@ -45,6 +51,7 @@ function formatEntity(e: EnrichedEntity): string {
   lines.push(`        status: 'active',`);
   if (s.publishedDate) lines.push(`        founded: '${s.publishedDate.slice(0, 7)}',`);
   lines.push('        sources: [');
+  lines.push('          // i18n-allow-unpaired — provenance for the pending-review stub above');
   lines.push('          {');
   lines.push(`            label: '${escapeQuote(e.candidate.label)}',`);
   lines.push(`            url: '${e.candidate.sourceUrl}',`);
@@ -152,6 +159,9 @@ export function emit(
         `i18n pairing regressed: ${baselineCount} → ${issuesAfter.length} unpaired. Rolled back.`
       );
     }
+
+    // Prettier-format the spliced-in entities so the PR passes check:prettier.
+    formatWithPrettier(filePath);
   }
 
   return { filePath, recordsAdded: accepted.length, perCategory, skipped };

--- a/scripts/refresh/legal-ai/run.ts
+++ b/scripts/refresh/legal-ai/run.ts
@@ -17,6 +17,7 @@ import { govFetch, listSitemap } from '../../lib/gov-fetch.ts';
 import { summarizePage } from '../../lib/ai-summarize.ts';
 import { autoCommit, pushAndOpenPR, buildPRBody } from '../../lib/auto-commit.ts';
 import { findUnpairedFields } from '../../lib/i18n-pair.ts';
+import { formatWithPrettier } from '../../lib/prettier-format.ts';
 import { loadState, saveState } from '../../lib/state.ts';
 
 const TARGET_FILE = resolve('src/data/legal-ai.ts');
@@ -324,6 +325,7 @@ async function main(): Promise<void> {
       `i18n pairing regressed: ${baselineCount} → ${issuesAfter.length} unpaired. Rolled back.`
     );
   }
+  formatWithPrettier(TARGET_FILE);
   process.stdout.write(`  added ${enriched.length} items to Auto-discovered section\n`);
 
   // Auto-discovered legal items go into a "pending review" section and

--- a/scripts/refresh/levers/run.ts
+++ b/scripts/refresh/levers/run.ts
@@ -15,6 +15,7 @@ import { govFetch, listSitemap } from '../../lib/gov-fetch.ts';
 import { summarizePage } from '../../lib/ai-summarize.ts';
 import { autoCommit, pushAndOpenPR, buildPRBody } from '../../lib/auto-commit.ts';
 import { findUnpairedFields } from '../../lib/i18n-pair.ts';
+import { formatWithPrettier } from '../../lib/prettier-format.ts';
 import { loadState, saveState } from '../../lib/state.ts';
 
 const TARGET_FILE = resolve('src/data/levers.ts');
@@ -308,6 +309,7 @@ async function main(): Promise<void> {
       `i18n pairing regressed: ${baselineCount} → ${issuesAfter.length} unpaired (introduced ${issuesAfter.length - baselineCount}). Rolled back.`
     );
   }
+  formatWithPrettier(TARGET_FILE);
   process.stdout.write(`  added ${enriched.length} items to Auto-discovered group\n`);
 
   // Auto-discovered lever items go into a sub-group under Lever 1 (not

--- a/scripts/refresh/policies/__tests__/emit-i18n-completeness.test.ts
+++ b/scripts/refresh/policies/__tests__/emit-i18n-completeness.test.ts
@@ -1,0 +1,133 @@
+// scripts/refresh/policies/__tests__/emit-i18n-completeness.test.ts
+// ────────────────────────────────────────────────────────────────────────
+// The emit formatters must produce records that satisfy the i18n gate run by
+// `i18n-pair --mode=both --locales=en,ja,ko` (CLAUDE.md rule #5):
+//
+//   - policies: `source` is a required, CJK-bearing field → it needs
+//     sourceEn / sourceJa / sourceKo siblings (the org name per source).
+//   - ecosystem: auto-discovered entities are `_pendingReview` stubs whose
+//     required analytical fields (whatItIs / aiRelevance / singaporeRelevance)
+//     and `sources[].label` siblings are filled by a human on promotion, so
+//     the emit marks them `// i18n-allow-unpaired` (the sanctioned escape
+//     hatch) — covering the entity AND its nested source object.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { formatPolicyRecord } from '../emit.ts';
+import type { EnrichedPolicy } from '../enrich.ts';
+import { formatEntity } from '../../ecosystem/emit.ts';
+import type { EnrichedEntity } from '../../ecosystem/enrich.ts';
+import { findUnpairedFields, findIncompleteRecords } from '../../../lib/i18n-pair.ts';
+import { I18N_CONFIG } from '../../../i18n-config.ts';
+
+function withTmpFile(content: string, fn: (path: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), 'sgai-emit-i18n-'));
+  try {
+    const path = join(dir, 'fixture.ts');
+    writeFileSync(path, content);
+    fn(path);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const policy: EnrichedPolicy = {
+  candidate: {
+    sourceUrl: 'https://www.mof.gov.sg/news/ai-budget-2026/',
+    domain: 'mof.gov.sg',
+    label: 'Ministry of Finance',
+    defaultCategory: '预算与资金',
+    defaultSource: '财政部 (MOF)',
+    defaultSourceEn: 'Ministry of Finance (MOF)',
+    defaultSourceJa: '財務省 (MOF)',
+    defaultSourceKo: '재정부 (MOF)',
+    defaultSourceOrgUrl: 'https://www.mof.gov.sg/',
+    defaultMinistry: 'MOF',
+  },
+  summary: {
+    sourceUrl: 'https://www.mof.gov.sg/news/ai-budget-2026/',
+    title: 'AI 预算 2026',
+    titleEn: 'AI Budget 2026',
+    titleJa: 'AI予算2026',
+    titleKo: 'AI 예산 2026',
+    description: '面向 AI 的财政预算说明。',
+    descriptionEn: 'A budget note for AI.',
+    descriptionJa: 'AI向け予算の説明。',
+    descriptionKo: 'AI 예산 설명.',
+    category: '预算与资金',
+    publishedDate: '2026-06-01',
+    confidence: 'high',
+    model: 'test',
+    generatedAt: '2026-06-19T00:00:00Z',
+  },
+  id: 'ai-budget-2026',
+  pageTitle: 'AI Budget 2026',
+  pageDate: '2026-06-01',
+  pdfUrl: null,
+  contentText: 'x',
+};
+
+const pendingEntity: EnrichedEntity = {
+  candidate: {
+    sourceUrl: 'https://aisingapore.org/labs/new-lab/',
+    domain: 'aisingapore.org',
+    label: 'AI Singapore',
+    defaultCategory: 'research',
+    defaultEntityType: 'research-lab',
+  },
+  summary: {
+    sourceUrl: 'https://aisingapore.org/labs/new-lab/',
+    title: '新实验室',
+    titleEn: 'New Lab',
+    titleJa: '新ラボ',
+    titleKo: '새 연구소',
+    description: '一个 AI 实验室。',
+    descriptionEn: 'An AI lab.',
+    descriptionJa: 'AIラボ。',
+    descriptionKo: 'AI 연구소.',
+    category: 'research',
+    publishedDate: null,
+    confidence: 'low',
+    _pendingReview: true,
+    model: 'test',
+    generatedAt: '2026-06-19T00:00:00Z',
+  },
+  id: 'new-lab',
+  pageTitle: 'New Lab',
+  pageDate: null,
+  contentText: 'x',
+};
+
+test('policies emit: source field carries en/ja/ko siblings', () => {
+  const record = formatPolicyRecord(policy, policy.candidate.defaultMinistry);
+  const wrapped = `export const x = [\n  {\n    policies: [\n${record}\n    ],\n  },\n];\n`;
+  withTmpFile(wrapped, (path) => {
+    const issues = findUnpairedFields(path, { fields: ['source'], locales: ['en', 'ja', 'ko'] });
+    assert.deepEqual(
+      issues,
+      [],
+      `source must carry en/ja/ko siblings; missing locales: ${JSON.stringify(issues.map((i) => i.locale))}`
+    );
+  });
+});
+
+const ecosystemSchema = I18N_CONFIG.find((c) => c.file === 'src/data/ecosystem.ts')!;
+
+test('ecosystem emit: _pendingReview stub + its nested source are exempt (escape hatch)', () => {
+  const entityStr = formatEntity(pendingEntity);
+  const wrapped = `export const x = [\n  {\n    entities: [\n${entityStr}\n    ],\n  },\n];\n`;
+  withTmpFile(wrapped, (path) => {
+    const issues = findIncompleteRecords(path, { schema: ecosystemSchema });
+    assert.deepEqual(
+      issues,
+      [],
+      `pending stub must be exempt from completeness; still flagged: ${JSON.stringify(
+        issues.map((i) => ({ schema: i.schema, missing: i.missingFields }))
+      )}`
+    );
+  });
+});

--- a/scripts/refresh/policies/__tests__/scan.test.ts
+++ b/scripts/refresh/policies/__tests__/scan.test.ts
@@ -1,0 +1,62 @@
+// scripts/refresh/policies/__tests__/scan.test.ts
+// ────────────────────────────────────────────────────────────────────────
+// Relevance filter regression. The 2026-06-19 sweep surfaced 5 candidates,
+// all generic smartnation.gov.sg landing / engagement / about / event pages
+// (captured in scripts/refresh/policies/data/raw/) — none substantive AI
+// policy documents. applyFilters must reject these while keeping real
+// article-depth policy URLs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { applyFilters } from '../scan.ts';
+import { POLICY_SOURCES } from '../sources.ts';
+
+const smartnation = POLICY_SOURCES.find((s) => s.domain === 'smartnation.gov.sg')!;
+const mddi = POLICY_SOURCES.find((s) => s.domain === 'mddi.gov.sg')!;
+
+// The exact junk URLs the sweep surfaced (from data/raw/ snapshots).
+const JUNK = [
+  'https://www.smartnation.gov.sg/initiatives/',
+  'https://www.smartnation.gov.sg/about/our-goals/goals-of-smart-nation/',
+  'https://www.smartnation.gov.sg/initiatives/programmes-and-initiatives/',
+  'https://www.smartnation.gov.sg/citizen-engagement/engagement-programmes/smart-nation-engagement-programmes/',
+  'https://www.smartnation.gov.sg/citizen-engagement/showcases/smart-nation-playscape/',
+  'https://www.smartnation.gov.sg/citizen-engagement/showcases/smart-nation-cityscape/',
+  'https://www.smartnation.gov.sg/citizen-engagement/showcases/smart-nation-showcases/',
+  'https://www.smartnation.gov.sg/events/singapore-ai-research-week-2025/',
+  'https://www.smartnation.gov.sg/citizen-engagement/engagement-programmes/smart-nation-ambassadors/',
+];
+
+// Article-depth pages that look like real policy / news documents — must survive.
+const LEGIT = [
+  'https://www.smartnation.gov.sg/initiatives/national-ai-strategy/',
+  'https://www.smartnation.gov.sg/initiatives/digital-government-blueprint/',
+  'https://www.smartnation.gov.sg/media-room/news/sg-launches-new-ai-testbed/',
+];
+
+test('applyFilters rejects all generic / landing / engagement smartnation pages', () => {
+  const result = applyFilters(JUNK, smartnation);
+  assert.deepEqual(result, [], `expected zero matches, got ${JSON.stringify(result)}`);
+});
+
+test('applyFilters keeps article-depth AI policy URLs', () => {
+  const result = applyFilters(LEGIT, smartnation);
+  assert.deepEqual([...result].sort(), [...LEGIT].sort(), `expected all legit URLs kept, got ${JSON.stringify(result)}`);
+});
+
+test('applyFilters keeps legit while dropping junk in a mixed batch', () => {
+  const result = applyFilters([...JUNK, ...LEGIT], smartnation);
+  assert.deepEqual([...result].sort(), [...LEGIT].sort());
+});
+
+test('generic-section denylist is shared across sources (mddi /about/ rejected)', () => {
+  const result = applyFilters(
+    [
+      'https://www.mddi.gov.sg/about/our-leadership/',
+      'https://www.mddi.gov.sg/newsroom/press-releases/2026/new-ai-governance-framework/',
+    ],
+    mddi
+  );
+  assert.deepEqual(result, ['https://www.mddi.gov.sg/newsroom/press-releases/2026/new-ai-governance-framework/']);
+});

--- a/scripts/refresh/policies/emit.ts
+++ b/scripts/refresh/policies/emit.ts
@@ -22,6 +22,7 @@ import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { findUnpairedFields } from '../../lib/i18n-pair.ts';
+import { formatWithPrettier } from '../../lib/prettier-format.ts';
 import type { EnrichedPolicy } from './enrich.ts';
 import type { PolicyCategoryName } from './sources.ts';
 
@@ -41,7 +42,7 @@ function escapeQuote(s: string): string {
   return s.replace(/'/g, "\\'");
 }
 
-function formatPolicyRecord(p: EnrichedPolicy, defaultMinistry?: string): string {
+export function formatPolicyRecord(p: EnrichedPolicy, defaultMinistry?: string): string {
   const s = p.summary;
   const date = (s.publishedDate || p.pageDate || new Date().toISOString().slice(0, 10)).slice(0, 7);
   const lines: string[] = [];
@@ -66,6 +67,8 @@ function formatPolicyRecord(p: EnrichedPolicy, defaultMinistry?: string): string
     lines.push('        contentJa: `' + escapeBacktick(s.descriptionJa) + '`,');
   }
   lines.push(`        sourceEn: '${escapeQuote(p.candidate.defaultSourceEn)}',`);
+  lines.push(`        sourceJa: '${escapeQuote(p.candidate.defaultSourceJa)}',`);
+  lines.push(`        sourceKo: '${escapeQuote(p.candidate.defaultSourceKo)}',`);
   if (defaultMinistry) {
     lines.push(`        ministry: '${defaultMinistry}',`);
   } else {
@@ -204,6 +207,9 @@ export function emit(
         `i18n pairing regressed: ${baselineCount} → ${issuesAfter.length} unpaired. Rolled back.`
       );
     }
+
+    // Prettier-format the spliced-in records so the PR passes check:prettier.
+    formatWithPrettier(filePath);
   }
 
   return {

--- a/scripts/refresh/policies/scan.ts
+++ b/scripts/refresh/policies/scan.ts
@@ -28,6 +28,8 @@ export interface PolicyCandidate {
   defaultCategory: string;
   defaultSource: string;
   defaultSourceEn: string;
+  defaultSourceJa: string;
+  defaultSourceKo: string;
   defaultSourceOrgUrl: string;
   defaultMinistry?: string;
 }
@@ -48,9 +50,65 @@ export interface ScanOptions {
   onlyDomain?: string;
 }
 
-function applyFilters(urls: string[], source: PolicySource): string[] {
+// Sections that never hold a substantive AI policy / news document. Applied
+// to ALL sources — the 2026-06-19 sweep surfaced only generic smartnation
+// engagement / about / event / showcase pages (matched via the `smart-nation`
+// token in AI_SLUG_KEYWORDS and the broad `/initiatives/` pattern). Keeping
+// this here (not per-source) means every source is protected and the
+// AI-keyword signal stays intact for real article pages.
+const GENERIC_SECTION_EXCLUDES: RegExp[] = [
+  /\/about(?:-us)?\//,
+  /\/citizen-engagement\//,
+  /\/engagement-programmes?\//,
+  /\/events?\//,
+  /\/showcases?\//,
+  /\/careers?\//,
+  /\/contact(?:-us)?\b/,
+  /\/faqs?\b/,
+  /\/feedback\//,
+  /\/newsletter\b/,
+  /\/subscribe\b/,
+  /\/our-people\//,
+  /\/leadership\//,
+  /\/tenders?\//,
+  /\/sitemap/,
+  /\/search\b/,
+];
+
+// Listing / section-index roots: the URL terminates at the section itself
+// with no article slug after it (e.g. `/initiatives/`,
+// `/initiatives/programmes-and-initiatives/`, `/news/`). Substantive
+// documents always carry a further slug.
+const LISTING_ROOTS = new Set([
+  'initiatives',
+  'programmes-and-initiatives',
+  'news',
+  'newsroom',
+  'media-room',
+  'press-releases',
+  'resources',
+  'publications',
+  'announcements',
+]);
+
+/** True when a URL is a generic section, an engagement/about page, or a bare
+ *  listing index rather than a specific policy / news document. */
+export function isGenericOrLanding(url: string): boolean {
+  let path: string;
+  try {
+    path = new URL(url).pathname;
+  } catch {
+    return true; // unparseable → drop
+  }
+  if (GENERIC_SECTION_EXCLUDES.some((re) => re.test(path))) return true;
+  const lastSeg = path.replace(/\/+$/, '').split('/').pop() || '';
+  return LISTING_ROOTS.has(lastSeg);
+}
+
+export function applyFilters(urls: string[], source: PolicySource): string[] {
   const out = new Set<string>();
   for (const url of urls) {
+    if (isGenericOrLanding(url)) continue;
     if (source.urlExcludes?.some((re) => re.test(url))) continue;
     if (!source.urlPatterns.some((re) => re.test(url))) continue;
     out.add(url);
@@ -159,6 +217,8 @@ export async function scan(options: ScanOptions): Promise<ScanResult> {
         defaultCategory: source.defaultCategory,
         defaultSource: source.defaultSource,
         defaultSourceEn: source.defaultSourceEn,
+        defaultSourceJa: source.defaultSourceJa,
+        defaultSourceKo: source.defaultSourceKo,
         defaultSourceOrgUrl: source.defaultSourceOrgUrl,
         defaultMinistry: source.defaultMinistry,
       });

--- a/scripts/refresh/policies/sources.ts
+++ b/scripts/refresh/policies/sources.ts
@@ -20,6 +20,10 @@ export interface PolicySource {
   defaultCategory: '国家战略' | '治理框架' | '行业监管' | '预算与资金' | '国际合作';
   defaultSource: string;
   defaultSourceEn: string;
+  /** ja / ko renderings of the org name (fixed per source; `source` is a
+   *  required CJK field, so it needs all locale siblings — see i18n rule #5). */
+  defaultSourceJa: string;
+  defaultSourceKo: string;
   defaultSourceOrgUrl: string;
   defaultMinistry?: string;
   /** Sitemap URL(s) to consult. */
@@ -41,6 +45,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '国家战略',
     defaultSource: '智慧国家与数字政府办公室 (SNDGO)',
     defaultSourceEn: 'Smart Nation and Digital Government Office (SNDGO)',
+    defaultSourceJa: 'スマート国家・デジタル政府オフィス (SNDGO)',
+    defaultSourceKo: '스마트네이션·디지털정부청 (SNDGO)',
     defaultSourceOrgUrl: 'https://www.smartnation.gov.sg/',
     sitemapUrls: ['https://www.smartnation.gov.sg/sitemap.xml'],
     urlPatterns: [/\/initiatives\//, /\/news\//, /\/media-room\//, AI_SLUG_KEYWORDS],
@@ -52,6 +58,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '国家战略',
     defaultSource: '数字发展与信息部 (MDDI)',
     defaultSourceEn: 'Ministry of Digital Development and Information (MDDI)',
+    defaultSourceJa: 'デジタル開発情報省 (MDDI)',
+    defaultSourceKo: '디지털개발정보부 (MDDI)',
     defaultSourceOrgUrl: 'https://www.mddi.gov.sg/',
     defaultMinistry: 'MDDI',
     sitemapUrls: ['https://www.mddi.gov.sg/sitemap.xml'],
@@ -64,6 +72,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '治理框架',
     defaultSource: '资讯通信媒体发展局 (IMDA)',
     defaultSourceEn: 'Infocomm Media Development Authority (IMDA)',
+    defaultSourceJa: '情報通信メディア開発庁 (IMDA)',
+    defaultSourceKo: '정보통신미디어개발청 (IMDA)',
     defaultSourceOrgUrl: 'https://www.imda.gov.sg/',
     sitemapUrls: ['https://www.imda.gov.sg/sitemap.xml'],
     listingUrls: ['https://www.imda.gov.sg/resources/press-releases-factsheets-and-speeches'],
@@ -75,6 +85,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '治理框架',
     defaultSource: 'AI Verify 基金会',
     defaultSourceEn: 'AI Verify Foundation',
+    defaultSourceJa: 'AI Verify 財団',
+    defaultSourceKo: 'AI Verify 재단',
     defaultSourceOrgUrl: 'https://aiverifyfoundation.sg/',
     sitemapUrls: ['https://aiverifyfoundation.sg/sitemap.xml'],
     urlPatterns: [/.*/],
@@ -85,6 +97,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '行业监管',
     defaultSource: '金融管理局 (MAS)',
     defaultSourceEn: 'Monetary Authority of Singapore (MAS)',
+    defaultSourceJa: 'シンガポール金融管理局 (MAS)',
+    defaultSourceKo: '싱가포르 통화청 (MAS)',
     defaultSourceOrgUrl: 'https://www.mas.gov.sg/',
     defaultMinistry: 'MOF',
     sitemapUrls: ['https://www.mas.gov.sg/sitemap.xml'],
@@ -97,6 +111,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '治理框架',
     defaultSource: '个人数据保护委员会 (PDPC)',
     defaultSourceEn: 'Personal Data Protection Commission (PDPC)',
+    defaultSourceJa: '個人データ保護委員会 (PDPC)',
+    defaultSourceKo: '개인정보보호위원회 (PDPC)',
     defaultSourceOrgUrl: 'https://www.pdpc.gov.sg/',
     sitemapUrls: ['https://www.pdpc.gov.sg/sitemap.xml'],
     urlPatterns: [/\/news/, /\/guidelines/, AI_SLUG_KEYWORDS],
@@ -107,6 +123,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '行业监管',
     defaultSource: '卫生部 (MOH)',
     defaultSourceEn: 'Ministry of Health (MOH)',
+    defaultSourceJa: '保健省 (MOH)',
+    defaultSourceKo: '보건부 (MOH)',
     defaultSourceOrgUrl: 'https://www.moh.gov.sg/',
     defaultMinistry: 'MOH',
     sitemapUrls: ['https://www.moh.gov.sg/sitemap.xml'],
@@ -118,6 +136,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '预算与资金',
     defaultSource: '国家研究基金会 (NRF)',
     defaultSourceEn: 'National Research Foundation (NRF)',
+    defaultSourceJa: '国立研究財団 (NRF)',
+    defaultSourceKo: '국가연구재단 (NRF)',
     defaultSourceOrgUrl: 'https://www.nrf.gov.sg/',
     sitemapUrls: ['https://www.nrf.gov.sg/sitemap.xml'],
     urlPatterns: [/\/news/, /\/funding/, AI_SLUG_KEYWORDS],
@@ -128,6 +148,8 @@ export const POLICY_SOURCES: PolicySource[] = [
     defaultCategory: '预算与资金',
     defaultSource: '财政部 (MOF)',
     defaultSourceEn: 'Ministry of Finance (MOF)',
+    defaultSourceJa: '財務省 (MOF)',
+    defaultSourceKo: '재정부 (MOF)',
     defaultSourceOrgUrl: 'https://www.mof.gov.sg/',
     defaultMinistry: 'MOF',
     sitemapUrls: ['https://www.mof.gov.sg/sitemap.xml'],


### PR DESCRIPTION
## What

Four bit-rot fixes so the auto-PR refresh pipelines pass the tightened CI gates — the 2026-06-19 sweep follow-ups, complementing #58.

### 1. `eval:addedAt` exempts pending-review records
`scripts/evals/addedAt-coverage/check.ts` counted every new `+ id:` (and anonymous `{`) as needing `addedAt`. Per CLAUDE.md rule #7, pending-review stubs must NOT carry `addedAt` until promoted. New `exemptLineRanges()` scans the working-tree file by brace/bracket depth for all three shapes:
- `autoDiscovered[]` const arrays (startups/tracker/talent/benchmarking — anonymous, no `id`)
- `_pendingReview` field/comment (ecosystem `_pendingReview: true`, policies `// _pendingReview`)
- "Auto-discovered (pending review)" groups/sections (levers/legal-ai)

`analyzeDiff()` maps each diff `+` line to its working-tree line via the `@@` hunk headers, then drops records in an exempt region. **Unblocks startups/levers/tracker/talent/benchmarking.**

### 2. Completeness gate (policies + ecosystem)
- **ecosystem**: `formatEntity` marks auto-discovered stubs `// i18n-allow-unpaired` on the entity **and its nested `sources[]`** object — `findIncompleteRecords` walks nested objects independently, so the entity-level comment alone would not exempt `sources[].label`. These are hidden `_pendingReview` stubs; the analytical fields (`whatItIs`/`aiRelevance`/`singaporeRelevance`) are human-curated on promotion (avoids LLM-fabricating analytical claims — rule #6).
- **policies**: added fixed `defaultSourceJa`/`defaultSourceKo` (org-name translations) to the 9 sources, threaded through `PolicyCandidate`, emitted as `sourceJa`/`sourceKo`.

### 3. Prettier before commit
New shared `scripts/lib/prettier-format.ts` (`formatWithPrettier()`, best-effort, mirrors `videos/emit.ts`), wired into all 5 emit paths: `auto-discovered-emit`, `levers/run`, `legal-ai/run`, `policies/emit`, `ecosystem/emit`. Fixes `check:prettier` failures that were hand-patched on #60/#61.

### 4. policies scanner over-match
New shared `isGenericOrLanding()` denylist in `applyFilters` drops generic landing/engagement/about/event/showcase pages + bare listing roots. The sweep surfaced only smartnation junk (`/initiatives/`, `/citizen-engagement/...`), caused by the `smart-nation` token in `AI_SLUG_KEYWORDS` matching the whole site plus the broad `/initiatives/` pattern.

## Tests — 13 new, wired into `test:lib` (runs in CI via `npm run check`)
- `scripts/evals/addedAt-coverage/__tests__/check.test.ts` (9) — all four pending-review shapes PASS without `addedAt`; real records still FAIL.
- `scripts/refresh/policies/__tests__/scan.test.ts` (4) — the exact junk URLs from the sweep rejected; article-depth URLs kept.
- `scripts/refresh/policies/__tests__/emit-i18n-completeness.test.ts` (2) — runs the real `formatPolicyRecord` / `formatEntity` through the i18n gate.

## Verification
- `npm run check` → exit 0 (astro 0 errors, prettier clean, 167 tests)
- `npm run eval:addedAt -- --base=origin/main` → 0 findings
- `npm run build && npm run check:dist` → exit 0 (5364 pages; 0 schema / i18n / zh-tw issues)
- `npx tsx scripts/lib/i18n-pair.ts --mode=both --locales=en,ja,ko src/data/ecosystem.ts src/data/policies.ts` → OK

## ⚠️ Merge order
Scripts-only — no `src/` or `src/data/` changes, so `dist/` is byte-identical to `main` (hence `check:dist` is a formality here). Fix #2's policies side adds only `source` ja/ko; the `title`/`summary`/`content` `ko` for policies is **#58's hunk**. **Merge #58 first** (or together) for policies emit to be fully ko-complete. The two PRs touch `formatPolicyRecord` at different lines and do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
