### PR TITLE
[data-refresh] levers: +3 items (pending review)

### DIFF
--- a/src/data/levers.ts
+++ b/src/data/levers.ts
@@ -423,6 +423,74 @@ export const levers: Lever[] = [
           },
         ],
       },
+      {
+        title: 'Auto-discovered (pending review)',
+        titleEn: 'Auto-discovered (pending review)',
+        titleJa: 'Auto-discovered（レビュー待ち）',
+        items: [
+          {
+            id: 'digital-leaders-programme',
+            name: '数字领袖计划',
+            nameEn: 'Digital Leaders Programme',
+            nameJa: 'デジタルリーダー計画',
+            nameKo: '디지털 리더십 프로그램',
+            ministry: 'Auto: 待审核',
+            ministryEn: 'Auto: pending review',
+            ministryJa: 'Auto: 審査待機中',
+            ministryKo: 'Auto: 검토 대기 중',
+            description: '新加坡IMDA的数字领袖计划相关页面。页面结构未能完全加载，具体计划内容、目标和详细信息缺失。',
+            descriptionEn:
+              "IMDA Singapore's Digital Leaders Programme page. The page content appears to be in a loading state with navigation elements only, lacking substantive information about the programme's objectives and details.",
+            descriptionJa:
+              'シンガポールIMDAのデジタルリーダー計画関連ページです。ページ構造が完全に読み込まれず、具体的な計画内容、目標、詳細情報が不足しています。',
+            descriptionKo:
+              '싱가포르 IMDA의 디지털 리더십 프로그램 관련 페이지입니다. 페이지 구조가 완전히 로드되지 않았으며, 구체적인 프로그램 내용, 목표 및 상세 정보가 누락되었습니다.',
+            sourceUrl:
+              'https://www.imda.gov.sg/about-imda/research-and-statistics/support-for-industry-sectors/enterprise-digital-transformation/digital-leaders-programme',
+          },
+          {
+            id: 'china-singapore-chongqing-demonstration-initiative-on-strategic-connectivity-cci',
+            name: '中新（重庆）战略联接示范倡议（CCI）- ICT 支柱',
+            nameEn: 'China-Singapore (Chongqing) Demonstration Initiative on Strategic Connectivity (CCI) – ICT Pillar',
+            nameJa: '中国・シンガポール（重慶）戦略的接続実証イニシアティブ（CCI）- ICT 柱',
+            nameKo: '중국-싱가포르(충칭) 전략적 연계 시범 이니셔티브(CCI) - ICT 기둥',
+            ministry: 'Auto: 待审核',
+            ministryEn: 'Auto: pending review',
+            ministryJa: 'Auto: 審査待機中',
+            ministryKo: 'Auto: 검토 대기 중',
+            description: '页面内容不完整，主要显示导航元素，无实质性内容。无法提供有意义的摘要。',
+            descriptionEn:
+              'Page content is incomplete, showing mainly navigation elements with no substantive content. Unable to provide a meaningful summary.',
+            descriptionJa:
+              'ページ内容が不完全であり、主にナビゲーション要素を表示しており、実質的な内容がありません。意味のある要約を提供することができません。',
+            descriptionKo:
+              '페이지 콘텐츠가 불완전하며, 주로 네비게이션 요소만 표시되고 실질적인 내용이 없습니다. 의미 있는 요약을 제공할 수 없습니다.',
+            sourceUrl:
+              'https://www.imda.gov.sg/about-imda/international-relations/international-partnerships/china-singapore-demonstration-initiative-on-strategic-connectivity',
+          },
+          {
+            id: 'national-multimodal-llm-programme',
+            name: '国家多模态大语言模型计划',
+            nameEn: 'National Multimodal LLM Programme',
+            nameJa: '国家マルチモーダル大規模言語モデル計画',
+            nameKo: '국가 다중모달 대규모 언어 모델 계획',
+            ministry: 'Auto: 待审核',
+            ministryEn: 'Auto: pending review',
+            ministryJa: 'Auto: 審査待機中',
+            ministryKo: 'Auto: 검토 대기 중',
+            description:
+              '页面内容无法有效获取。提供的源文本仅包含页面导航元素和加载状态，未包含关于该计划的实质性信息。',
+            descriptionEn:
+              'The source content could not be effectively retrieved. The provided text contains only page navigation elements and loading indicators without substantive information about the programme.',
+            descriptionJa:
+              'ページの内容を有効に取得できませんでした。提供されたソーステキストは、ページのナビゲーション要素とロード状態のみを含んでおり、本計画に関する実質的な情報は含まれていません。',
+            descriptionKo:
+              '페이지 콘텐츠를 효과적으로 획득할 수 없습니다. 제공된 원본 텍스트는 페이지 네비게이션 요소 및 로딩 상태만 포함하고 있으며, 해당 계획에 관한 실질적 정보를 포함하지 않습니다.',
+            sourceUrl:
+              'https://www.imda.gov.sg/about-imda/emerging-technologies-and-research/national-multimodal-llm-programme',
+          },
+        ],
+      },
     ],
     insight: '国家把企业最大的固定成本（算力 + 数据）变成公共物品。',
     insightKo: '국가가 기업의 최대 고정 비용(컴퓨팅 파워 + 데이터)을 공공재로 전환합니다.',


### PR DESCRIPTION
## Summary
- Domain: `levers`
- New entries: **3**
- Confidence: 0 high · 0 medium · 3 low
- ⚠️ 3 low-confidence entries marked `_pendingReview: true` (not rendered until cleared).

## New entries
- Digital Leaders Programme _(low)_ — https://www.imda.gov.sg/about-imda/research-and-statistics/support-for-industry-sectors/enterprise-digital-transformation/digital-leaders-programme
- China-Singapore (Chongqing) Demonstration Initiative on Strategic Connectivity (CCI) – ICT Pillar _(low)_ — https://www.imda.gov.sg/about-imda/international-relations/international-partnerships/china-singapore-demonstration-initiative-on-strategic-connectivity
- National Multimodal LLM Programme _(low)_ — https://www.imda.gov.sg/about-imda/emerging-technologies-and-research/national-multimodal-llm-programme

## Diff
```
src/data/levers.ts | 68 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 68 insertions(+)
```

🤖 Generated by sgai data-refresh pipeline.

> Items added to lever 1's "Auto-discovered (pending review)" group. AI proposed a category — review and move to the right lever.